### PR TITLE
メール送信時のステータス変更の流れを変更

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.framework'
-version = '1.1.0'
+version = '1.2.0'
 description = 'メール送信機能(NAFから外れる)'
 
 buildscript {

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   // Mail API
   compile 'javax.mail:mailapi:1.4.3'
 
+  testCompile 'org.jmockit:jmockit:1.30'
   testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-all:1.3'
   testCompile 'com.nablarch.dev:nablarch-test-support:0.0.5'

--- a/src/test/java/nablarch/common/mail/MailTestSupport.java
+++ b/src/test/java/nablarch/common/mail/MailTestSupport.java
@@ -1,6 +1,6 @@
 package nablarch.common.mail;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -23,11 +23,9 @@ import javax.mail.PasswordAuthentication;
 import javax.mail.Session;
 import javax.mail.Store;
 
-import nablarch.test.support.log.app.OnMemoryLogWriter;
-import nablarch.fw.ExecutionContext;
-import nablarch.fw.Handler;
 import nablarch.fw.results.TransactionAbnormalEnd;
 import nablarch.test.support.db.helper.VariousDbTestHelper;
+import nablarch.test.support.log.app.OnMemoryLogWriter;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -123,22 +121,6 @@ public class MailTestSupport {
         assertThat("エラーの型", catched, instanceOf(TransactionAbnormalEnd.class));
         assertThat("終了コード", ((TransactionAbnormalEnd) catched).getStatusCode(), is(abnormalEndExitCode));
         assertThat("メッセージ", catched.getMessage(), is("メール送信に失敗しました。 mailRequestId=[" + mailReqestId + "]"));
-    }
-
-    public static class MailTestErrorHandler implements Handler<Object, Object> {
-
-        protected static Exception catched;
-
-        /** {@inheritDoc} */
-        public Object handle(Object req, ExecutionContext ctx) {
-
-            try {
-                return ctx.handleNext(req);
-            } catch (RuntimeException e) {
-                catched = e;
-                throw e;
-            }
-        }
     }
 
     public void assertAttachedFile(Part part, File file) throws IOException, MessagingException {

--- a/src/test/resources/app-log.properties
+++ b/src/test/resources/app-log.properties
@@ -1,5 +1,5 @@
 failureLogFormatter.defaultFailureCode=MSG99999
-failureLogFormatter.defaultMessage=想定外エラー
+failureLogFormatter.defaultMessage=\u60F3\u5B9A\u5916\u30A8\u30E9\u30FC
 failureLogFormatter.language=ja
 
 

--- a/src/test/resources/log.properties
+++ b/src/test/resources/log.properties
@@ -3,6 +3,8 @@ loggerFactory.className=nablarch.core.log.basic.BasicLoggerFactory
 writerNames=memory,stdout
 
 writer.memory.className=nablarch.test.support.log.app.OnMemoryLogWriter
+writer.memory.formatter.className=nablarch.core.log.basic.BasicLogFormatter
+writer.memory.formatter.format=-$logLevel$- $message$$information$$stackTrace$
 
 # stdout
 writer.stdout.className=nablarch.core.log.basic.StandardOutputLogWriter

--- a/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTest.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTest.xml
@@ -29,6 +29,12 @@
     <component name="commitLogger" class="nablarch.core.log.app.BasicCommitLogger">
         <property name="interval" value="500" />
     </component>
+  
+    <component name="statusUpdateTransaction" class="nablarch.core.db.transaction.SimpleDbTransactionManager">
+      <property name="dbTransactionName" value="statusUpdateTransaction" />
+      <property name="connectionFactory" ref="connectionFactory" />
+      <property name="transactionFactory" ref="jdbcTransactionFactory" />
+    </component>
 
     <!-- ハンドラキュー構成 -->
     <list name="handlerQueue">
@@ -36,8 +42,6 @@
         <component class="nablarch.fw.handler.StatusCodeConvertHandler" />
         <!-- グローバルエラーハンドラ -->
         <component class="nablarch.fw.handler.GlobalErrorHandler" />
-        <!-- エラー検証用の専用ハンドラ -->
-        <component class="nablarch.common.mail.MailSenderPatternIdSupportTest$MailTestErrorHandler" />
         <!-- スレッドコンテキスト設定ハンドラ -->
         <component-ref name="threadContextHandler" />
         <!-- 常駐化ハンドラ （テスト時は戻ってこさせるためにはずす） -->

--- a/src/test/resources/nablarch/common/mail/MailSenderTest.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderTest.xml
@@ -33,15 +33,18 @@
         <property name="interval" value="500" />
     </component>
 
+    <component name="statusUpdateTransaction" class="nablarch.core.db.transaction.SimpleDbTransactionManager">
+      <property name="dbTransactionName" value="statusUpdateTransaction" />
+      <property name="connectionFactory" ref="connectionFactory" />
+      <property name="transactionFactory" ref="jdbcTransactionFactory" />
+    </component>
+
     <!-- ハンドラキュー構成 -->
     <list name="handlerQueue">
         <!-- ステータスコードを終了コードに変換するハンドラ -->
         <component class="nablarch.fw.handler.StatusCodeConvertHandler" />
         <!-- グローバルエラーハンドラ -->
         <component class="nablarch.fw.handler.GlobalErrorHandler" />
-        <!-- エラー検証用の専用ハンドラ -->
-        <component
-            class="nablarch.common.mail.MailSenderTest$MailTestErrorHandler" />
         <!-- スレッドコンテキスト設定ハンドラ -->
         <component-ref name="threadContextHandler" />
         <!-- ２重起動防止ハンドラ -->


### PR DESCRIPTION
メール送信時のステータス変更の流れを変更

変更後
1. メール送信前にステータスを送信済みに変更する
2. メール送信失敗時にはステータスを送信失敗に変更する
   このときにDB関連の障害が発生した場合は、ステータスにパッチをあてる必要が有ることをしめす例外を送出する

なお、1と2は独立したトランザクションで行い即時コミットを行う。

NAB-8 メール送信要求が不正でもメール送信バッチをアベンドさせたくない