### PR TITLE
メール送信時のMessagingExceptionのハンドルの仕様を修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.framework'
-version = '1.1.0'
+version = '1.2.0'
 description = 'メール送信機能(NAFから外れる)'
 
 buildscript {
@@ -29,6 +29,7 @@ dependencies {
   // Mail API
   compile 'javax.mail:mailapi:1.4.3'
 
+  testCompile 'org.jmockit:jmockit:1.30'
   testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-all:1.3'
   testCompile 'com.nablarch.dev:nablarch-test-support:0.0.5'

--- a/src/main/java/nablarch/common/mail/CreateMailFailedException.java
+++ b/src/main/java/nablarch/common/mail/CreateMailFailedException.java
@@ -1,0 +1,31 @@
+package nablarch.common.mail;
+
+import javax.mail.MessagingException;
+
+/**
+ * メール作成時の失敗を表す例外。<br/>
+ * MessagingExceptionをラップする際に、入力情報を含めることでより詳細なメッセージを作成できる。
+ *
+ * @author T.Shimoda
+ */
+public class CreateMailFailedException extends MessagingException {
+
+    /**
+     * コンストラクタ。
+     *
+     * @param message 例外メッセージ
+     * @param cause 起因例外
+     */
+    public CreateMailFailedException(String message, Exception cause) {
+        super(message, cause);
+    }
+
+    /**
+     * コンストラクタ。
+     *
+     * @param message 例外メッセージ
+     */
+    public CreateMailFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nablarch/common/mail/InvalidCharacterException.java
+++ b/src/main/java/nablarch/common/mail/InvalidCharacterException.java
@@ -1,13 +1,11 @@
 package nablarch.common.mail;
 
-import javax.mail.MessagingException;
-
 /**
  * 不正な文字が含まれていた場合に発生する例外。
  * 
  * @author Kohei Sawaki
  */
-public class InvalidCharacterException extends MessagingException {
+public class InvalidCharacterException extends CreateMailFailedException {
 
     /**
      * InvalidCharacterExceptionを生成する。

--- a/src/main/java/nablarch/common/mail/MailAttachedFileTable.java
+++ b/src/main/java/nablarch/common/mail/MailAttachedFileTable.java
@@ -189,6 +189,7 @@ public class MailAttachedFileTable implements Initializable {
      *
      * @author hisaaki shioiri
      */
+    @Published(tag = "architect")
     public static class MailAttachedFile {
 
         /** 添付ファイル管理の1レコード分の情報を保持するオブジェクト */

--- a/src/main/java/nablarch/common/mail/MailRequestTable.java
+++ b/src/main/java/nablarch/common/mail/MailRequestTable.java
@@ -297,14 +297,20 @@ public class MailRequestTable implements Initializable {
      * @param mailRequestId メールリクエストID
      * @param status ステータス
      */
-    public void updateStatus(String mailRequestId, String status) {
-        AppDbConnection connection = DbConnectionContext.getConnection();
-        SqlPStatement statement = connection.prepareStatement(updateStatusSql);
-        statement.setString(1, status);
-        statement.setTimestamp(2, SystemTimeUtil.getTimestamp());
-        statement.setString(3, mailRequestId);
-        statement.setString(4, mailConfig.getStatusUnsent());
-        statement.executeUpdate();
+    public void updateStatus(final String mailRequestId, final String status) {
+        final SimpleDbTransactionManager transaction = SystemRepository.get("statusUpdateTransaction");
+        new SimpleDbTransactionExecutor<Void>(transaction) {
+            @Override
+            public Void execute(final AppDbConnection connection) {
+                final SqlPStatement statement = connection.prepareStatement(updateStatusSql);
+                statement.setString(1, status);
+                statement.setTimestamp(2, SystemTimeUtil.getTimestamp());
+                statement.setString(3, mailRequestId);
+                statement.setString(4, mailConfig.getStatusUnsent());
+                statement.executeUpdate();
+                return null;
+            }
+        }.doTransaction();
     }
 
     /**
@@ -315,13 +321,19 @@ public class MailRequestTable implements Initializable {
      * @param mailRequestId メールリクエストID
      * @param status ステータス
      */
-    public void updateFailureStatus(String mailRequestId, String status) {
-        AppDbConnection connection = DbConnectionContext.getConnection();
-        SqlPStatement statement = connection.prepareStatement(updateFailureStatusSql);
-        statement.setString(1, status);
-        statement.setString(2, mailRequestId);
-        statement.setString(3, mailConfig.getStatusUnsent());
-        statement.executeUpdate();
+    public void updateFailureStatus(final String mailRequestId, final String status) {
+        final SimpleDbTransactionManager transaction = SystemRepository.get("statusUpdateTransaction");
+        new SimpleDbTransactionExecutor<Void>(transaction) {
+            @Override
+            public Void execute(final AppDbConnection connection) {
+                final SqlPStatement statement = connection.prepareStatement(updateFailureStatusSql);
+                statement.setString(1, status);
+                statement.setString(2, mailRequestId);
+                statement.setString(3, mailConfig.getStatusSent());
+                statement.executeUpdate();
+                return null;
+            }
+        }.doTransaction();
     }
 
     /**
@@ -437,7 +449,8 @@ public class MailRequestTable implements Initializable {
     private String createUpdateFailureStatusSql() {
         return "UPDATE " + tableName
                 + " SET "
-                + statusColumnName + " = ? "
+                + statusColumnName + " = ?, "
+                + sendDateTimeColumnName + " = null "
                 + "WHERE " + mailRequestIdColumnName + " = ?"
                 + " AND " + statusColumnName + " = ?";
     }

--- a/src/main/java/nablarch/common/mail/MailSender.java
+++ b/src/main/java/nablarch/common/mail/MailSender.java
@@ -7,7 +7,9 @@ import java.util.UUID;
 
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
+import javax.mail.Address;
 import javax.mail.MessagingException;
+import javax.mail.SendFailedException;
 import javax.mail.Session;
 import javax.mail.Transport;
 import javax.mail.internet.AddressException;
@@ -19,15 +21,19 @@ import javax.mail.util.ByteArrayDataSource;
 
 import nablarch.core.date.SystemTimeUtil;
 import nablarch.core.db.statement.SqlRow;
+import nablarch.core.log.Logger;
+import nablarch.core.log.LoggerManager;
+import nablarch.core.log.app.FailureLogUtil;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.annotation.Published;
 import nablarch.fw.DataReader;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.Result;
-import nablarch.fw.reader.DatabaseRecordListener;
-import nablarch.fw.results.TransactionAbnormalEnd;
 import nablarch.fw.action.BatchAction;
+import nablarch.fw.launcher.ProcessAbnormalEnd;
+import nablarch.fw.reader.DatabaseRecordListener;
 import nablarch.fw.reader.DatabaseRecordReader;
+import nablarch.fw.results.TransactionAbnormalEnd;
 
 /**
  * メール送信要求管理テーブル上の各レコードごとにメール送信を行うバッチアクション。
@@ -38,6 +44,9 @@ public class MailSender extends BatchAction<SqlRow> {
 
     /** メール送信バッチを識別するプロセスID */
     private final String processId = UUID.randomUUID().toString();
+
+    /** ロガー */
+    private final Logger LOGGER = LoggerManager.get(MailSender.class);
 
     /**
      * コンストラクタ。
@@ -68,12 +77,16 @@ public class MailSender extends BatchAction<SqlRow> {
         // メールセッションの取得
         Session session = createMailSession(mailRequest.getReturnPath(), mailSenderConfig);
 
+        MailConfig mailConfig = SystemRepository.get("mailConfig");
         try {
+            // 2重送信防止のため、送信ステータスをはじめに送信済みに更新する。
+            updateToSuccess(data, context);
+
             // 差し戻し先メールアドレスのチェック
             containsInvalidCharacter(mailRequest.getReturnPath(), mailRequestId);
 
             // メッセージの作成
-            MimeMessage mimeMessage = createMimeMessage(mailRequestId, mailRequest, session, mailRecipientTable);
+            MimeMessage mimeMessage = createMimeMessage(data, mailRequestId, mailRequest, session, mailRecipientTable);
 
             // 添付ファイルの情報を取得
             List<? extends MailAttachedFileTable.MailAttachedFile> attachedFiles = mailAttachedFileTable.find(
@@ -84,18 +97,131 @@ public class MailSender extends BatchAction<SqlRow> {
             // 設定の保存とメール送信
             mimeMessage.saveChanges();
             Transport.send(mimeMessage);
-        } catch (MessagingException e) {
-            MailConfig mailConfig = SystemRepository.get("mailConfig");
-            throw new TransactionAbnormalEnd(
-                    mailConfig.getAbnormalEndExitCode(), e,
-                    mailConfig.getSendFailureCode(), mailRequestId);
+            writeLog(mailConfig.getSendSuccessMessageId(), mailRequestId);
+        } catch (CreateMailFailedException e) {
+            writeCreateMailFailedLog(data, mailRequest, mailConfig, e);
+            updateToFailed(data, context);
+            return createTransactionAbnormalEnd(mailRequest, mailConfig, e);
+        } catch (SendFailedException e) {
+            writeSendMailFailedLog(data, mailRequest, mailConfig, e);
+            updateToFailed(data, context);
+            return createTransactionAbnormalEnd(mailRequest, mailConfig, e);
+        } catch (ProcessAbnormalEnd e) {
+            updateToFailed(data, context);
+            throw e;
+        } catch (Exception e) {
+            return handleException(data, context, mailRequest, mailConfig, e);
         }
         return new Result.Success();
     }
 
     /**
+     * メール送信時の例外のハンドル処理を行う。
+     * <p/>
+     * 本クラスでは、障害ログを出力し、送信ステータスを送信失敗にしてリトライを行う。
+     * 本メソッドでは、すべての例外をリトライ対象として{@link SendMailRetryableException}を送出している。
+     * 独自の処理を実施したい場合は本メソッドをオーバーライドすることで行うことができる。
+     *
+     * @param data 入力データ（メール送信要求のレコード）
+     * @param context 実行コンテキスト
+     * @param mailRequest メール送信要求
+     * @param mailConfig メール設定
+     * @param e メール送信時の例外
+     * @return {@link #handle(SqlRow, ExecutionContext)} が返す処理結果
+     */
+    @Published(tag = "architect")
+    protected Result handleException(final SqlRow data, final ExecutionContext context,
+            final MailRequestTable.MailRequest mailRequest, final MailConfig mailConfig, final Exception e) {
+        FailureLogUtil.logError(e, data, mailConfig.getSendFailureCode(), mailRequest.getMailRequestId());
+        updateToFailed(data, context);
+        throw new SendMailRetryableException(
+                String.format(
+                        "Failed to send a mail, will be retried to send later. mailRequestId=[%s], error message=[%s]",
+                        mailRequest.getMailRequestId(), e.getMessage()), e);
+    }
+
+
+    /**
+     * メール送信失敗時の{@link SendFailedException}例外の障害検知ログに出力する。
+     * <p/>
+     * メール送信失敗時に、独自の処理を実施したい場合は本メソッドをオーバーライドすることで行うことができる。
+     *
+     * @param data 入力データ（メール送信要求のレコード）
+     * @param mailRequest メール送信要求
+     * @param mailConfig メール設定
+     * @param e メール送信失敗時の{@link SendFailedException}例外
+     */
+    @Published(tag = "architect")
+    protected void writeSendMailFailedLog(final SqlRow data, final MailRequestTable.MailRequest mailRequest,
+            final MailConfig mailConfig, final SendFailedException e) {
+        final String sentAddresses = createStringFromAddresses(e.getValidSentAddresses());
+        final String unsentAddresses = createStringFromAddresses(e.getValidUnsentAddresses());
+        final String invalidAddresses = createStringFromAddresses(e.getInvalidAddresses());
+        final CreateMailFailedException ce = new CreateMailFailedException(
+                String.format("Failed to send a mail. Error message:[%s] Mail RequestId:[%s] "
+                                + "Sent address:[%s] Unsent address:[%s] Invalid address:[%s]",
+                        e.getMessage(), mailRequest.getMailRequestId(),
+                        sentAddresses, unsentAddresses, invalidAddresses), e);
+        FailureLogUtil.logError(ce, data, mailConfig.getSendFailureCode(), mailRequest.getMailRequestId());
+    }
+
+    /**
+     * メールアドレスの配列を文字列にする。
+     *
+     * @param addresses メールアドレスの配列
+     * @return メールアドレスをカンマで連結した文字列
+     */
+    private static String createStringFromAddresses(final Address[] addresses) {
+        if (addresses == null) {
+            return "";
+        }
+        final StringBuilder result = new StringBuilder();
+        for (Address address : addresses) {
+            if (result.length() > 0) {
+                result.append(", ");
+            }
+            result.append(address);
+        }
+        return result.toString();
+    }
+
+    /**
+     * メール作成が失敗した場合に、障害検知ログに出力する。
+     * <p/>
+     * メール作成が失敗した時に、独自の処理を実施したい場合は本メソッドをオーバーライドすることで行うことができる。
+     *
+     * @param data 入力データ（メール送信要求のレコード）
+     * @param mailRequest メール送信要求
+     * @param mailConfig メール設定
+     * @param e {@link MessagingException}
+     */
+    @Published(tag = "architect")
+    protected void writeCreateMailFailedLog(final SqlRow data, final MailRequestTable.MailRequest mailRequest,
+            final MailConfig mailConfig, final MessagingException e) {
+        FailureLogUtil.logError(e, data, mailConfig.getSendFailureCode(), mailRequest.getMailRequestId());
+    }
+
+    /**
+     * メール送信時に送信失敗を表す{@link MessagingException}が発生した場合のトランザクションの異常終了例外を生成して返す。
+     *
+     * @param mailRequest メール送信要求
+     * @param mailConfig メール設定
+     * @param e メール送信時のMessagingException
+     * @return 業務トランザクションの異常終了例外
+     */
+    private TransactionAbnormalEnd createTransactionAbnormalEnd(final MailRequestTable.MailRequest mailRequest,
+            final MailConfig mailConfig, final MessagingException e) {
+        return new TransactionAbnormalEnd(
+                mailConfig.getAbnormalEndExitCode(),
+                e,
+                mailConfig.getSendFailureCode(),
+                mailRequest.getMailRequestId());
+    }
+
+    /**
      * メールデータを作成する。
      *
+     * @param data 入力データ（メール送信要求のレコード）
      * @param mailRequestId メール送信要求ID
      * @param mailRequest メール送信先情報
      * @param session メールセッション
@@ -104,15 +230,18 @@ public class MailSender extends BatchAction<SqlRow> {
      * @throws MessagingException メールメッセージの生成に失敗した場合
      */
     @Published(tag = "architect")
-    protected MimeMessage createMimeMessage(String mailRequestId, MailRequestTable.MailRequest mailRequest,
+    protected MimeMessage createMimeMessage(final SqlRow data, String mailRequestId,
+            MailRequestTable.MailRequest mailRequest,
             Session session, MailRecipientTable mailRecipientTable) throws MessagingException {
 
         MailConfig mailConfig = SystemRepository.get("mailConfig");
 
+        // エラーの発生したアドレス
+        List<String> errorAddresses = new ArrayList<String>();
         // 各送信先の取得
-        InternetAddress[] to = getAddresses(mailRequestId, mailConfig.getRecipientTypeTO(), mailRecipientTable);
-        InternetAddress[] cc = getAddresses(mailRequestId, mailConfig.getRecipientTypeCC(), mailRecipientTable);
-        InternetAddress[] bcc = getAddresses(mailRequestId, mailConfig.getRecipientTypeBCC(), mailRecipientTable);
+        InternetAddress[] to = getAddresses(mailRequest, mailConfig.getRecipientTypeTO(), mailRecipientTable, errorAddresses);
+        InternetAddress[] cc = getAddresses(mailRequest, mailConfig.getRecipientTypeCC(), mailRecipientTable,errorAddresses);
+        InternetAddress[] bcc = getAddresses(mailRequest, mailConfig.getRecipientTypeBCC(), mailRecipientTable, errorAddresses);
 
         MimeMessage mimeMessage = new MimeMessage(session);
         // 宛先の設定
@@ -121,12 +250,34 @@ public class MailSender extends BatchAction<SqlRow> {
         mimeMessage.setRecipients(MimeMessage.RecipientType.BCC, bcc);
 
         // 送信元の設定
-        mimeMessage.setFrom(new InternetAddress(mailRequest.getFrom()));
+        final InternetAddress from = createInternetAddress(mailRequest.getFrom(), mailRequest);
+        if (from != null) {
+            mimeMessage.setFrom(from);
+        } else {
+            errorAddresses.add(mailRequest.getFrom());
+        }
 
         // 返信先の設定
-        InternetAddress[] replyTo = new InternetAddress[1];
-        replyTo[0] = new InternetAddress(mailRequest.getReplyAddress());
-        mimeMessage.setReplyTo(replyTo);
+        final InternetAddress replyTo = createInternetAddress(mailRequest.getReplyAddress(), mailRequest);
+        if (replyTo != null) {
+            mimeMessage.setReplyTo(new InternetAddress[] {replyTo});
+        } else {
+            errorAddresses.add(mailRequest.getReplyAddress());
+        }
+
+        // 不正なアドレスがあれば例外を送出
+        if (!errorAddresses.isEmpty()) {
+            StringBuilder addresses = new StringBuilder();
+            for (String address : errorAddresses) {
+                if (addresses.length() > 0) {
+                    addresses.append(", ");
+                }
+                addresses.append(address);
+            }
+            throw new CreateMailFailedException(
+                    String.format("Invalid mail addresses found. mailRequestId=[%s] mail addresses=[%s]",
+                            mailRequestId, addresses.toString()));
+        }
 
         // 件名のチェック
         containsInvalidCharacter(mailRequest.getSubject(), mailRequestId);
@@ -216,24 +367,26 @@ public class MailSender extends BatchAction<SqlRow> {
     /**
      * 指定したメール送信要求IDと送信先区分に紐付くメールアドレスの配列を取得する。
      *
-     * @param mailRequestId メール送信要求ID
+     * @param mailRequest メール送信要求
      * @param recipientType 宛先区分
      * @param mailRecipientTable 宛先メールアドレスの配列
+     * @param errorAddresses 生成に失敗したアドレスのリスト
      * @return メールアドレスの配列
      */
-    private InternetAddress[] getAddresses(String mailRequestId,
-            String recipientType, MailRecipientTable mailRecipientTable) {
+    private InternetAddress[] getAddresses(MailRequestTable.MailRequest mailRequest,
+            String recipientType, MailRecipientTable mailRecipientTable, List<String> errorAddresses) {
 
-        List<? extends MailRecipientTable.MailRecipient> mailRecipients = mailRecipientTable.find(mailRequestId,
+        List<? extends MailRecipientTable.MailRecipient> mailRecipients = mailRecipientTable.find(mailRequest.getMailRequestId(),
                 recipientType);
 
         List<InternetAddress> mailAddresses = new ArrayList<InternetAddress>();
         for (MailRecipientTable.MailRecipient mailRecipient : mailRecipients) {
-            try {
-                mailAddresses.add(new InternetAddress(mailRecipient.getMailAddress()));
-            } catch (AddressException e) {
-                // メールアドレスはバリデーション済みのため、到達しないはず。
-                throw new IllegalStateException(e);
+            final String address = mailRecipient.getMailAddress();
+            final InternetAddress mailAddress = createInternetAddress(address, mailRequest);
+            if (mailAddress != null) {
+                mailAddresses.add(mailAddress);
+            } else {
+                errorAddresses.add(address);
             }
         }
 
@@ -241,19 +394,38 @@ public class MailSender extends BatchAction<SqlRow> {
     }
 
     /**
+     * メールアドレスを生成する。{@link AddressException}が発生した場合は、ログを出力しnullを返す。
+     *
+     * @param address メールアドレスの元となる文字列
+     * @param mailRequest メール送信要求
+     * @return 生成したメールアドレス
+     */
+    private InternetAddress createInternetAddress(final String address,
+            final MailRequestTable.MailRequest mailRequest) {
+        try {
+            return new InternetAddress(address);
+        } catch (AddressException e) {
+            LOGGER.logWarn(String.format(
+                    "Failed to instantiate mail address. mailRequestId=[%s] mail address=[%s] error message=[%s]",
+                    mailRequest.getMailRequestId(), address, e.getMessage()), e);
+            return null;
+        }
+    }
+
+    /**
      * メールヘッダ・インジェクションチェック<br />
      * チェック対象文字列に\rもしくは\nを含んでいるかのチェック。
      * <p/>
      * チェック内容を変更する場合や、チェック結果の振る舞いを変更する場合には本メソッドをオーバライドし処理をチェック処理を変更すること。
-     * 
+     *
      * @param target チェック対象文字列
      * @param mailRequestId メール送信要求ID
-     * @throws InvalidCharacterException チェック対象文字列に\rもしくは\nを含んでいた場合 
+     * @throws InvalidCharacterException チェック対象文字列に\rもしくは\nを含んでいた場合
      */
     @Published(tag = "architect")
     protected void containsInvalidCharacter(String target, String mailRequestId) throws InvalidCharacterException {
         if (target.contains("\r") || target.contains("\n")) {
-            throw new InvalidCharacterException(String.format("contains invalid character. mailRequestId = %s, target = %s", 
+            throw new InvalidCharacterException(String.format("contains invalid character. mailRequestId = %s, target = %s",
                     mailRequestId, target));
         }
     }
@@ -286,34 +458,44 @@ public class MailSender extends BatchAction<SqlRow> {
     }
 
     /**
-     * {@inheritDoc}
-     * <p/>
      * 処理ステータスを異常終了に更新する。
+     * <p/>
+     * 更新時に例外が発生した場合は、{@link ProcessAbnormalEnd}を送出する。
+     *
+     * @param data 送信対象データ
+     * @param context 実行コンテキスト
      */
-    @Override
     @Published(tag = "architect")
-    protected void transactionFailure(SqlRow data, ExecutionContext context) {
-        MailRequestTable mailRequestTable = SystemRepository.get("mailRequestTable");
-        MailRequestTable.MailRequest mailRequest = mailRequestTable.getMailRequest(data);
-        MailConfig mailConfig = SystemRepository.get("mailConfig");
-
-        mailRequestTable.updateFailureStatus(mailRequest.getMailRequestId(), mailConfig.getStatusFailure());
+    protected void updateToFailed(final SqlRow data, final ExecutionContext context) {
+        final MailRequestTable mailRequestTable = SystemRepository.get("mailRequestTable");
+        final MailRequestTable.MailRequest mailRequest = mailRequestTable.getMailRequest(data);
+        final MailConfig mailConfig = SystemRepository.get("mailConfig");
+        try {
+            mailRequestTable.updateFailureStatus(mailRequest.getMailRequestId(), mailConfig.getStatusFailure());
+        } catch (RuntimeException re) {
+            throw new ProcessAbnormalEnd(
+                    mailConfig.getAbnormalEndExitCode(),
+                    new SendStatusUpdateFailureException(
+                            String.format("Failed to update unsent status. Need to apply a patch to change "
+                                            + "the status to failure. mailRequestId=[%s]",
+                                    mailRequest.getMailRequestId()), re),
+                    mailConfig.getSendFailureCode(),
+                    mailRequest.getMailRequestId());
+        }
     }
 
     /**
-     * {@inheritDoc}
-     * <p/>
-     * 処理ステータスを正常終了に更新し、送信ログを出力する。
+     * 処理ステータスを正常終了に更新する。
+     *
+     * @param data 送信対象データ
+     * @param context 実行コンテキスト
      */
-    @Override
     @Published(tag = "architect")
-    protected void transactionSuccess(SqlRow data, ExecutionContext context) {
-        MailRequestTable mailRequestTable = SystemRepository.get("mailRequestTable");
-        MailRequestTable.MailRequest mailRequest = mailRequestTable.getMailRequest(data);
-        MailConfig mailConfig = SystemRepository.get("mailConfig");
+    protected void updateToSuccess(final SqlRow data, final ExecutionContext context) {
+        final MailRequestTable mailRequestTable = SystemRepository.get("mailRequestTable");
+        final MailRequestTable.MailRequest mailRequest = mailRequestTable.getMailRequest(data);
+        final MailConfig mailConfig = SystemRepository.get("mailConfig");
 
-        String mailRequestId = mailRequest.getMailRequestId();
-        mailRequestTable.updateStatus(mailRequestId, mailConfig.getStatusSent());
-        writeLog(mailConfig.getSendSuccessMessageId(), mailRequestId);
+        mailRequestTable.updateStatus(mailRequest.getMailRequestId(), mailConfig.getStatusSent());
     }
 }

--- a/src/main/java/nablarch/common/mail/SendMailRetryableException.java
+++ b/src/main/java/nablarch/common/mail/SendMailRetryableException.java
@@ -1,0 +1,23 @@
+package nablarch.common.mail;
+
+import nablarch.core.util.annotation.Published;
+import nablarch.fw.handler.retry.RetryableException;
+
+/**
+ * メール送信時にリトライ可能である状態を示す例外
+ *
+ * @author T.Shimoda
+ */
+@Published(tag = "architect")
+public class SendMailRetryableException extends RetryableException {
+
+    /**
+     * コンストラクタ。
+     *
+     * @param message 例外メッセージ
+     * @param cause 起因例外
+     */
+    public SendMailRetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/nablarch/common/mail/SendStatusUpdateFailureException.java
+++ b/src/main/java/nablarch/common/mail/SendStatusUpdateFailureException.java
@@ -1,0 +1,20 @@
+package nablarch.common.mail;
+
+/**
+ * メール送信時の送信ステータス更新に失敗した状態を示す例外
+ * 本例外が発生した際は、送信ステータスが未送信から送信済みまたは送信失敗へ失敗したことを表す。
+ *
+ * @author T.Shimoda
+ */
+public class SendStatusUpdateFailureException extends RuntimeException {
+
+    /**
+     * コンストラクタ。
+     *
+     * @param message 例外メッセージ
+     * @param cause 起因例外
+     */
+    public SendStatusUpdateFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/nablarch/common/mail/MailSenderTest.java
+++ b/src/test/java/nablarch/common/mail/MailSenderTest.java
@@ -17,30 +17,39 @@ import javax.mail.Address;
 import javax.mail.Authenticator;
 import javax.mail.Folder;
 import javax.mail.Message;
+import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.Part;
 import javax.mail.PasswordAuthentication;
+import javax.mail.SendFailedException;
 import javax.mail.Session;
 import javax.mail.Store;
+import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage.RecipientType;
 
 import nablarch.core.date.BasicSystemTimeProvider;
 import nablarch.core.date.SystemTimeUtil;
+import nablarch.core.db.DbAccessException;
 import nablarch.core.util.FileUtil;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.Handler;
 import nablarch.fw.launcher.CommandLine;
 import nablarch.fw.launcher.Main;
+import nablarch.fw.launcher.ProcessAbnormalEnd;
 import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.db.helper.DatabaseTestRunner;
 import nablarch.test.support.db.helper.TargetDb;
 import nablarch.test.support.db.helper.VariousDbTestHelper;
+import nablarch.test.support.log.app.OnMemoryLogWriter;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import mockit.Mock;
+import mockit.MockUp;
 
 /**
  * {@link MailSender}のテストクラス。
@@ -72,6 +81,7 @@ public class MailSenderTest extends MailTestSupport {
                 new MailTestMessage("REQ_COUNT0", "en", "{0} records of mail request selected."));
 
         VariousDbTestHelper.setUpTable(new MailBatchRequest("SENDMAIL00", "メール送信バッチ", "0", "0", "1"));
+        OnMemoryLogWriter.clear();
     }
 
     public static class TestSystemTimeProvider extends BasicSystemTimeProvider {
@@ -133,12 +143,20 @@ public class MailSenderTest extends MailTestSupport {
         session.setDebug(true);
         Store store = session.getStore("pop3");
         store.connect();
-        Folder folder = openFolder(store);
+        //メールの削除と取得のタイムラグの間に他のテストケースで送信したメールが複数届く場合があるため、
+        //Subjectが一致するものを待つ。
+        Folder folder = openFolder(store, subject);
         Message[] messages = folder.getMessages();
-        assertThat("メールが1通とどいているはず", messages.length, is(1));
+        Message message = null;
+        for (Message mail: messages ) {
+            if( subject.equals(mail.getSubject()) ) {
+                message = mail;
+                break;
+            }
+        }
+        assertThat("件名[" + subject + "]が一致するメールが届いていない", message, notNullValue());
 
         // メールの検証
-        Message message = messages[0];
         Address[] messageFrom = message.getFrom();
         assertThat("fromアドレスの数", messageFrom.length, is(1));
         assertThat("fromアドレス", ((InternetAddress) messageFrom[0]).getAddress(), is(from));
@@ -230,9 +248,18 @@ public class MailSenderTest extends MailTestSupport {
         });
         Store store1 = session.getStore("pop3");
         store1.connect();
-        Folder folder1 = openFolder(store1);
+        //メールの削除と取得のタイムラグの間に他のテストケースで送信したメールが複数届く場合があるため、
+        //Subjectが一致するものを待つ。
+        Folder folder1 = openFolder(store1, subject);
         Message[] messages = folder1.getMessages();
-        assertThat("メールが1通とどいているはず", messages.length, is(1));
+        Message message = null;
+        for (Message mail: messages ) {
+            if( subject.equals(mail.getSubject()) ) {
+                message = mail;
+                break;
+            }
+        }
+        assertThat("件名[" + subject + "]が一致するメールが届いていない", message, notNullValue());
 
         // メールの検証
         Message message1 = messages[0];
@@ -288,9 +315,16 @@ public class MailSenderTest extends MailTestSupport {
         });
         Store store2 = session2.getStore("pop3");
         store2.connect();
-        Folder folder2 = openFolder(store2);
+        Folder folder2 = openFolder(store2, subject);
         Message[] messages2 = folder2.getMessages();
-        assertThat("メールが1通とどいているはず", messages2.length, is(1));
+        Message message2 = null;
+        for (Message mail: messages2 ) {
+            if( subject.equals(mail.getSubject()) ) {
+                message2 = mail;
+                break;
+            }
+        }
+        assertThat("件名[" + subject + "]が一致するメールが届いていない", message2, notNullValue());
 
         Session session3 = Session.getInstance(sessionProperties, new Authenticator() {
             protected PasswordAuthentication getPasswordAuthentication() {
@@ -299,9 +333,16 @@ public class MailSenderTest extends MailTestSupport {
         });
         Store store3 = session3.getStore("pop3");
         store3.connect();
-        Folder folder3 = openFolder(store3);
+        Folder folder3 = openFolder(store3, subject);
         Message[] messages3 = folder3.getMessages();
-        assertThat("メールが1通とどいているはず", messages3.length, is(1));
+        Message message3 = null;
+        for (Message mail: messages3 ) {
+            if( subject.equals(mail.getSubject()) ) {
+                message3 = mail;
+                break;
+            }
+        }
+        assertThat("件名[" + subject + "]が一致するメールが届いていない", message3, notNullValue());
 
         // DBの検証（ステータスと送信日時）
         List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
@@ -363,7 +404,7 @@ public class MailSenderTest extends MailTestSupport {
         });
         Store store1 = session1.getStore("pop3");
         store1.connect();
-        Folder folder1 = openFolder(store1);
+        Folder folder1 = openFolder(store1, subject);
         Message[] messages = folder1.getMessages();
         assertThat("メールが1通とどいているはず", messages.length, is(1));
 
@@ -448,30 +489,51 @@ public class MailSenderTest extends MailTestSupport {
     public void testExecuteAbnormalEndConnectionRefused() throws SQLException {
 
         // データ準備
-        String mailRequestId = "4";
-        String subject = "異常系1(接続エラー)";
+        String mailRequestId1 = "4-1";
+        String subject1 = "異常系1-1(接続エラー)";
+        String mailRequestId2 = "4-2";
+        String subject2 = "異常系1-2(接続エラー)";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
 
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 2L, mailConfig.getRecipientTypeTO(), to1));
 
         // バッチ実行
         CommandLine commandLine = new CommandLine("-diConfig",
                 "nablarch/common/mail/MailSenderTestOverrideSmtpPort.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("接続エラー(MessagingException)はリトライで上限に達して異常終了して戻り値は180となる。", execute, is(180));
 
-        assertError(MailTestErrorHandler.catched, mailRequestId, mailConfig.getAbnormalEndExitCode());
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[4-1], error message=[",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[4-2], error message=[",
+                "req_id = [SENDMAIL00] usr_id = [hoge] application was abnormal end.");
+        //障害通知ログに[4-1]と[4-2]が１回ずつ出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[4-1]"
+                ),1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[4-2]"
+                ),1);
 
         // DBの検証（ステータスと送信日時）
-        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
-        assertThat("レコード取得数", mailRequestList.size(), is(1));
-        assertThat("ステータスが「送信失敗」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
         assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, is(nullValue()));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, is(nullValue()));
     }
 
     /**
@@ -487,30 +549,51 @@ public class MailSenderTest extends MailTestSupport {
     public void testExecuteAbnormalEndConnectionTimeout() throws SQLException {
 
         // データ準備
-        String mailRequestId = "5";
-        String subject = "異常系2（接続タイムアウト）";
+        String mailRequestId1 = "5-1";
+        String subject1 = "異常系2-1（接続タイムアウト）";
+        String mailRequestId2 = "5-2";
+        String subject2 = "異常系2-2（接続タイムアウト）";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
 
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 2L, mailConfig.getRecipientTypeTO(), to1));
 
         // バッチ実行
         CommandLine commandLine = new CommandLine("-diConfig",
                 "nablarch/common/mail/MailSenderTestOverrideSmtpConnetcionTimeout.xml",
                 "-requestPath", "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("タイムアウト(MessagingException)はリトライで上限に達して異常終了し戻り値は180となる。", execute, is(180));
 
-        assertError(MailTestErrorHandler.catched, mailRequestId, mailConfig.getAbnormalEndExitCode());
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[5-1], error message=[",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[5-2], error message=[",
+                "req_id = [SENDMAIL00] usr_id = [hoge] application was abnormal end.");
+        //障害通知ログに[5-1]と[5-2]が１回ずつ出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[5-1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[5-2]"
+                ), 1);
 
         // DBの検証（ステータスと送信日時）
-        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
-        assertThat("レコード取得数", mailRequestList.size(), is(1));
-        assertThat("ステータスが「送信失敗」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class,"mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
         assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, is(nullValue()));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, is(nullValue()));
     }
 
     /**
@@ -525,30 +608,50 @@ public class MailSenderTest extends MailTestSupport {
     @Test
     public void testExecuteAbnormalEndSendError() throws SQLException {
         // データ準備
-        String mailRequestId = "6";
-        String subject = "異常系4(送信エラー）";
+        String mailRequestId1 = "6-1";
+        String subject1 = "異常系3-1(送信エラー）";
+        String mailRequestId2 = "6-2";
+        String subject2 = "異常系3-2(送信エラー）";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, "aaaa", mailConfig.getStatusUnsent(),
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, "aaaa", mailConfig.getStatusUnsent(),
+                        SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, "aaaa", mailConfig.getStatusUnsent(),
                         SystemTimeUtil.getTimestamp(), null, mailBody));
 
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 2L, mailConfig.getRecipientTypeTO(), to1));
 
         // バッチ実行
         CommandLine commandLine = new CommandLine("-diConfig",
-                "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
+                "nablarch/common/mail/MailSenderTestRetry.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("タイムアウト(MessagingException)はリトライで上限に達して異常終了し戻り値は180となる。", execute, is(180));
 
-        assertError(MailTestErrorHandler.catched, mailRequestId, mailConfig.getAbnormalEndExitCode());
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[6-1], error message=[",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[6-2], error message=[",
+                "req_id = [SENDMAIL00] usr_id = [hoge] application was abnormal end.");
+        //障害通知ログに[6-1]と[6-2]が１回ずつ出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[6-1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory", createMessagePattern(
+                "-ERROR- MONITOR [",
+                "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[6-2]"
+        ), 1);
 
         // DBの検証（ステータスと送信日時）
-        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
-        assertThat("レコード取得数", mailRequestList.size(), is(1));
-        assertThat("ステータスが「送信失敗」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
         assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, is(nullValue()));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, is(nullValue()));
     }
 
     /**
@@ -564,54 +667,85 @@ public class MailSenderTest extends MailTestSupport {
     public void testExecuteAbnormalEndSendTimeout() throws Exception {
 
         // データ準備
-        String mailRequestId = "7";
-        String subject = "異常系4(送信タイムアウト）";
+        String mailRequestId1 = "7-1";
+        String subject1 = "異常系4-1(送信タイムアウト）";
+        String mailRequestId2 = "7-2";
+        String subject2 = "異常系4-2(送信タイムアウト）";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
 
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 2L, mailConfig.getRecipientTypeTO(), to1));
 
         // バッチ実行
         CommandLine commandLine = new CommandLine("-diConfig",
                 "nablarch/common/mail/MailSenderTestOverrideSmtpTimeout.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("タイムアウト(MessagingException)はリトライで上限に達して異常終了し戻り値は180となる。", execute, is(180));
 
-        assertError(MailTestErrorHandler.catched, mailRequestId, mailConfig.getAbnormalEndExitCode());
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[7-1], error message=[",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[7-2], error message=[",
+                "req_id = [SENDMAIL00] usr_id = [hoge] application was abnormal end.");
+        //障害通知ログに[7-1]と[7-2]が１回ずつ出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[7-1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[7-2]"
+                ), 1);
 
         // DBの検証（ステータスと送信日時）
-        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
-        assertThat("レコード取得数", mailRequestList.size(), is(1));
-        assertThat("ステータスが「送信失敗」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class,"mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
         assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, is(nullValue()));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, is(nullValue()));
     }
 
     /**
      * {@link Main#execute(CommandLine)}のテスト。
      * <p/>
-     * 処理が異常終了する場合のテスト<br/>
+     * 一部メールの送信に失敗する場合のテスト<br/>
      * <br/>
      * メールアドレス(To)でExceptionが発生するパターン。
      *
      * @throws Exception
      */
     @Test
-    public void testExecuteAbnormalEndAddressExceptionTo() throws Exception {
+    public void testSendFailAddressExceptionTo() throws Exception {
 
         // データ準備
-        String mailRequestId = "1";
-        String subject = "正常系";
+        final String invalidAddress = to1 + "\rhoge";
+        String mailRequestId1 = "1";
+        String subject1 = "TOアドレスが不正";
+        String mailRequestId2 = "2";
+        String subject2 = "正常系TO 前のメールが送信失敗でも中断せず送信される";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
 
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1 + "\rhoge"));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), invalidAddress),
+                new MailRecipient(mailRequestId1, 2L, mailConfig.getRecipientTypeCC(), cc1),
+                new MailRecipient(mailRequestId1, 3L, mailConfig.getRecipientTypeBCC(), bcc1),
+                new MailRecipient(mailRequestId2, 4L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 5L, mailConfig.getRecipientTypeCC(), cc1),
+                new MailRecipient(mailRequestId2, 6L, mailConfig.getRecipientTypeBCC(), bcc1));
 
         //LogVerifier.setExpectedLogMessages(new ArrayList<Map<String,String>>() {
         //    {
@@ -629,35 +763,72 @@ public class MailSenderTest extends MailTestSupport {
                 "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は20となる。", execute, is(20));
+        assertThat("送信失敗は異常終了ではなく戻り値は0となる。", execute, is(0));
 
         // ----- assert log -----
         //LogVerifier.verify("assert log");
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Invalid mail addresses found. mailRequestId=[1] mail addresses=[" + invalidAddress + "]",
+                "Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidAddress + "]",
+                "メール送信に失敗しました。 mailRequestId=[1]",
+                "メールを送信しました。 mailRequestId=[2]");
+        //障害通知ログに[1]と、Invalid mail addresses のstackTraceが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "nablarch.common.mail.CreateMailFailedException: Invalid mail addresses found. mailRequestId=[1] mail addresses=["
+                                + invalidAddress + "]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, is(nullValue()));
+        assertThat("ステータスが「送信成功」", mailRequestList.get(1).status, is(mailConfig.getStatusSent()));
+        assertThat("送信日時が登録されているはず", mailRequestList.get(1).sendDatetime, notNullValue());
+
+        // メールの検証
+        assertRecivingPlainMail("to1", from, replyTo, subject2, new String[]{to1}, new String[]{cc1});
     }
 
     /**
      * {@link Main#execute(CommandLine)}のテスト。
      * <p/>
-     * 処理が異常終了する場合のテスト<br/>
+     * 一部メールの送信に失敗する場合のテスト<br/>
      * <br/>
      * メールアドレス（CC）でExceptionが発生するパターン。
      *
      * @throws Exception
      */
     @Test
-    public void testExecuteAbnormalEndAddressExceptionCC() throws Exception {
+    public void testSendFailAddressExceptionCC() throws Exception {
 
         // データ準備
-        String mailRequestId = "1";
-        String subject = "正常系";
+        final String invalidAddress = cc1 + "\rhoge";
+        String mailRequestId1 = "1";
+        String subject1 = "CCアドレスが不正";
+        String mailRequestId2 = "2";
+        String subject2 = "正常系CC 前のメールが送信失敗でも中断せず送信される";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
 
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1),
-                new MailRecipient(mailRequestId, 2L, mailConfig.getRecipientTypeCC(), cc1 + "\rhoge"));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId1, 2L, mailConfig.getRecipientTypeCC(), invalidAddress),
+                new MailRecipient(mailRequestId1, 3L, mailConfig.getRecipientTypeBCC(), bcc1),
+                new MailRecipient(mailRequestId2, 4L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 5L, mailConfig.getRecipientTypeCC(), cc1),
+                new MailRecipient(mailRequestId2, 6L, mailConfig.getRecipientTypeBCC(), bcc1));
 
         //LogVerifier.setExpectedLogMessages(new ArrayList<Map<String,String>>() {
         //    {
@@ -675,35 +846,72 @@ public class MailSenderTest extends MailTestSupport {
                 "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は20となる。", execute, is(20));
+        assertThat("送信失敗は異常終了ではなく戻り値は0となる。", execute, is(0));
 
         // ----- assert log -----
         //LogVerifier.verify("assert log");
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Invalid mail addresses found. mailRequestId=[1] mail addresses=[" + invalidAddress + "]",
+                "Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidAddress + "]",
+                "メール送信に失敗しました。 mailRequestId=[1]",
+                "メールを送信しました。 mailRequestId=[2]");
+        //障害通知ログに[1]と、Invalid mail addresses のstackTraceが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "nablarch.common.mail.CreateMailFailedException: Invalid mail addresses found. mailRequestId=[1] mail addresses=["
+                                + invalidAddress + "]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, is(nullValue()));
+        assertThat("ステータスが「送信成功」", mailRequestList.get(1).status, is(mailConfig.getStatusSent()));
+        assertThat("送信日時が登録されているはず", mailRequestList.get(1).sendDatetime, notNullValue());
+
+        // メールの検証
+        assertRecivingPlainMail("to1", from, replyTo, subject2, new String[]{to1}, new String[]{cc1});
     }
 
     /**
      * {@link Main#execute(CommandLine)}のテスト。
      * <p/>
-     * 処理が異常終了する場合のテスト<br/>
+     * 一部メールの送信に失敗する場合のテスト<br/>
      * <br/>
      * メールアドレス（BCC）でExceptionが発生するパターン。
      *
      * @throws Exception
      */
     @Test
-    public void testExecuteAbnormalEndAddressExceptionBCC() throws Exception {
+    public void testSendFailAddressExceptionBCC() throws Exception {
 
         // データ準備
-        String mailRequestId = "1";
-        String subject = "正常系";
+        final String invalidAddress = "hoge\n" + bcc1;
+        String mailRequestId1 = "1";
+        String subject1 = "BCCアドレスが不正";
+        String mailRequestId2 = "2";
+        String subject2 = "正常系BCC 前のメールが送信失敗でも中断せず送信される";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
 
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1),
-                new MailRecipient(mailRequestId, 2L, mailConfig.getRecipientTypeTO(), "hoge\n" + bcc1));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId1, 2L, mailConfig.getRecipientTypeCC(), cc1),
+                new MailRecipient(mailRequestId1, 3L, mailConfig.getRecipientTypeBCC(), invalidAddress),
+                new MailRecipient(mailRequestId2, 4L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 5L, mailConfig.getRecipientTypeCC(), cc1),
+                new MailRecipient(mailRequestId2, 6L, mailConfig.getRecipientTypeBCC(), bcc1));
 
         //LogVerifier.setExpectedLogMessages(new ArrayList<Map<String,String>>() {
         //    {
@@ -721,34 +929,64 @@ public class MailSenderTest extends MailTestSupport {
                 "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は20となる。", execute, is(20));
+        assertThat("送信失敗は異常終了ではなく戻り値は0となる。", execute, is(0));
 
-        // ----- assert log -----
-        //LogVerifier.verify("assert log");
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Invalid mail addresses found. mailRequestId=[1] mail addresses=[" + invalidAddress + "]",
+                "Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidAddress + "]",
+                "メール送信に失敗しました。 mailRequestId=[1]",
+                "メールを送信しました。 mailRequestId=[2]");
+        //障害通知ログに[1]と、Invalid mail addresses のstackTraceが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "nablarch.common.mail.CreateMailFailedException: Invalid mail addresses found. mailRequestId=[1] mail addresses=["
+                                + invalidAddress + "]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, is(nullValue()));
+        assertThat("ステータスが「送信成功」", mailRequestList.get(1).status, is(mailConfig.getStatusSent()));
+        assertThat("送信日時が登録されているはず", mailRequestList.get(1).sendDatetime, notNullValue());
+
+        // メールの検証
+        assertRecivingPlainMail("to1", from, replyTo, subject2, new String[]{to1}, new String[]{cc1});
     }
 
     /**
      * {@link Main#execute(CommandLine)}のテスト。
      * <p/>
-     * 処理が異常終了する場合のテスト<br/>
+     * 一部メールの送信に失敗する場合のテスト<br/>
      * <br/>
      * 送信者メールアドレスでExceptionが発生するパターン。
      *
      * @throws Exception
      */
     @Test
-    public void testExecuteAbnormalEndAddressExceptionFrom() throws Exception {
-
+    public void testSendFailAddressExceptionFrom() throws Exception {
         // データ準備
-        String mailRequestId = "1";
-        String subject = "正常系";
+        final String invalidAddress = from + "\rhoge";
+        String mailRequestId1 = "1";
+        String subject1 = "送信者メールアドレスが不正";
+        String mailRequestId2 = "2";
+        String subject2 = "正常系FROM 前のメールが送信失敗でも中断せず送信される";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from + "\rhoge", replyTo, returnPath, charset,
+                new MailRequest(mailRequestId1, subject1, invalidAddress, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
-
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 2L, mailConfig.getRecipientTypeTO(), to1)
+        );
 
         //LogVerifier.setExpectedLogMessages(new ArrayList<Map<String,String>>() {
         //    {
@@ -766,34 +1004,67 @@ public class MailSenderTest extends MailTestSupport {
                 "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("送信失敗は異常終了ではなく戻り値は0となる。", execute, is(0));
 
         // ----- assert log -----
         //LogVerifier.verify("assert log");
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Invalid mail addresses found. mailRequestId=[1] mail addresses=[" + invalidAddress + "]",
+                "Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidAddress + "]",
+                "メール送信に失敗しました。 mailRequestId=[1]",
+                "メールを送信しました。 mailRequestId=[2]");
+        //障害通知ログに[1]と、Invalid mail addresses のstackTraceが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "nablarch.common.mail.CreateMailFailedException: Invalid mail addresses found. mailRequestId=[1] mail addresses=["
+                                + invalidAddress + "]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されない", mailRequestList.get(0).sendDatetime, nullValue());
+        assertThat("ステータスが「送信成功」", mailRequestList.get(1).status, is(mailConfig.getStatusSent()));
+        assertThat("送信日時が登録されているはず", mailRequestList.get(1).sendDatetime, notNullValue());
+
+        // メールの検証
+        assertRecivingPlainMail("to1", from, replyTo, subject2, new String[]{to1}, new String[]{});
     }
 
     /**
      * {@link Main#execute(CommandLine)}のテスト。
      * <p/>
-     * 処理が異常終了する場合のテスト<br/>
+     * 一部メールの送信に失敗する場合のテスト<br/>
      * <br/>
      * 返信先メールアドレスでExceptionが発生するパターン。
      *
      * @throws Exception
      */
     @Test
-    public void testExecuteAbnormalEndAddressExceptionReplyTo() throws Exception {
-
+    public void testSendFailAddressExceptionReplyTo() throws Exception {
         // データ準備
-        String mailRequestId = "1";
-        String subject = "正常系";
+        final String invalidAddress = "hoge\n" + replyTo;
+        String mailRequestId1 = "1";
+        String subject1 = "返信先メールアドレスが不正";
+        String mailRequestId2 = "2";
+        String subject2 = "正常系ReplyTo 前のメールが送信失敗でも中断せず送信される";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, "hoge\n" + replyTo, returnPath, charset,
+                new MailRequest(mailRequestId1, subject1, from, invalidAddress, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
-
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 2L, mailConfig.getRecipientTypeTO(), to1)
+        );
 
         //LogVerifier.setExpectedLogMessages(new ArrayList<Map<String,String>>() {
         //    {
@@ -811,10 +1082,141 @@ public class MailSenderTest extends MailTestSupport {
                 "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("送信失敗は異常終了ではなく戻り値は0となる。", execute, is(0));
 
         // ----- assert log -----
         //LogVerifier.verify("assert log");
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Invalid mail addresses found. mailRequestId=[1] mail addresses=[" + invalidAddress + "]",
+                "Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidAddress + "]",
+                "メール送信に失敗しました。 mailRequestId=[1]",
+                "メールを送信しました。 mailRequestId=[2]");
+        //障害通知ログに[1]と、Invalid mail addresses のstackTraceが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "nablarch.common.mail.CreateMailFailedException: Invalid mail addresses found. mailRequestId=[1] mail addresses=["
+                                + invalidAddress + "]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されない", mailRequestList.get(0).sendDatetime, nullValue());
+        assertThat("ステータスが「送信成功」", mailRequestList.get(1).status, is(mailConfig.getStatusSent()));
+        assertThat("送信日時が登録されているはず", mailRequestList.get(1).sendDatetime, notNullValue());
+
+        // メールの検証
+        assertRecivingPlainMail("to1", from, replyTo, subject2, new String[]{to1}, new String[]{});
+    }
+
+    /**
+     * {@link Main#execute(CommandLine)}のテスト。
+     * <p/>
+     * 複数のアドレスが不正でメールの送信に失敗する場合のテスト<br/>
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendFailMultipleAddressExceptions() throws Exception {
+        // データ準備
+        final String invalidFrom = from + "@";
+        final String invalidReplyTo = replyTo + "@";
+        final String invalidTo1 = to1 + "@";
+        final String invalidCc1 = cc1 + "@";
+        final String invalidBcc1 = bcc1 + "@";
+
+        String mailRequestId1 = "1";
+        String subject1 = "メールアドレスが複数不正";
+
+        VariousDbTestHelper.setUpTable(
+                new MailRequest(mailRequestId1, subject1, invalidFrom, invalidReplyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody)
+        );
+        VariousDbTestHelper.setUpTable(
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId1, 2L, mailConfig.getRecipientTypeTO(), invalidTo1),
+                new MailRecipient(mailRequestId1, 3L, mailConfig.getRecipientTypeCC(), cc1),
+                new MailRecipient(mailRequestId1, 4L, mailConfig.getRecipientTypeCC(), invalidCc1),
+                new MailRecipient(mailRequestId1, 5L, mailConfig.getRecipientTypeBCC(), bcc1),
+                new MailRecipient(mailRequestId1, 6L, mailConfig.getRecipientTypeBCC(), invalidBcc1)
+        );
+
+        //LogVerifier.setExpectedLogMessages(new ArrayList<Map<String,String>>() {
+        //    {
+        //        add(new HashMap<String, String>() {
+        //            {
+        //                put("logLevel", "FATAL");
+        //                put("message1", "Local address contains control or whitespace");
+        //            }
+        //        });
+        //    }
+        //});
+
+        // バッチ実行
+        CommandLine commandLine = new CommandLine("-diConfig",
+                "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
+                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
+        int execute = Main.execute(commandLine);
+        assertThat("送信失敗は異常終了ではなく戻り値は0となる。", execute, is(0));
+
+        // ----- assert log -----
+        //LogVerifier.verify("assert log");
+
+        String invalidAddresses = invalidTo1 + ", " + invalidCc1 + ", " + invalidBcc1 + ", " + invalidFrom + ", " + invalidReplyTo;
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Invalid mail addresses found. mailRequestId=[1] mail addresses=[" + invalidAddresses + "]",
+                "メール送信に失敗しました。 mailRequestId=[1]");
+        //不正なアドレスがすべて警告として出力されていること
+        assertLogWithCount("writer.memory",
+                createMessagePattern(
+                        "-WARN- ROO [",
+                        "] req_id = [SENDMAIL00] usr_id = [hoge] Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidTo1
+                ), 1);
+        assertLogWithCount("writer.memory",
+                createMessagePattern(
+                        "-WARN- ROO [",
+                        "] req_id = [SENDMAIL00] usr_id = [hoge] Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidCc1
+                ), 1);
+        assertLogWithCount("writer.memory",
+                createMessagePattern(
+                        "-WARN- ROO [",
+                        "] req_id = [SENDMAIL00] usr_id = [hoge] Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidBcc1
+                ), 1);
+        assertLogWithCount("writer.memory",
+                createMessagePattern(
+                        "-WARN- ROO [",
+                        "] req_id = [SENDMAIL00] usr_id = [hoge] Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidFrom
+                ), 1);
+        assertLogWithCount("writer.memory",
+                createMessagePattern(
+                        "-WARN- ROO [",
+                        "] req_id = [SENDMAIL00] usr_id = [hoge] Failed to instantiate mail address. mailRequestId=[1] mail address=[" + invalidReplyTo
+                ), 1);
+
+        //障害通知ログに[1]と、Invalid mail addresses のstackTraceが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "nablarch.common.mail.CreateMailFailedException: Invalid mail addresses found. mailRequestId=[1] mail addresses=["
+                                + invalidAddresses + "]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(1));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されない", mailRequestList.get(0).sendDatetime, nullValue());
     }
 
     /**
@@ -830,15 +1232,20 @@ public class MailSenderTest extends MailTestSupport {
     public void testExecuteAbnormalEndAddressExceptionCharset() throws Exception {
 
         // データ準備
-        String mailRequestId = "1";
-        String subject = "正常系";
+        String mailRequestId1 = "1";
+        String subject1 = "文字セットが不正1";
+        String mailRequestId2 = "2";
+        String subject2 = "文字セットが不正2";
 
         VariousDbTestHelper.setUpTable(
-                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset + "\nhoge",
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, charset + "\nhoge",
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset + "\nhoge",
                         mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
 
         VariousDbTestHelper.setUpTable(
-                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 1L, mailConfig.getRecipientTypeTO(), to1));
 
         //LogVerifier.setExpectedLogMessages(new ArrayList<Map<String,String>>() {
         //    {
@@ -851,28 +1258,50 @@ public class MailSenderTest extends MailTestSupport {
         //    }
         //});
 
-        // バッチ実行
+        // バッチ実行 (リトライするハンドラ構成でのテスト)
         CommandLine commandLine = new CommandLine("-diConfig",
-                "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
+                "nablarch/common/mail/MailSenderTestRetry.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("送信失敗でリトライ上限に達して戻り値は180になる。", execute, is(180));
+        //障害通知ログに[1]と[2]が１回ずつ出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[2]"
+                ), 1);
 
         // ----- assert log -----
         //LogVerifier.verify("assert log");
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "nablarch.common.mail.SendMailRetryableException: Failed to send a mail, will be retried to send later. mailRequestId=[1], error message=[");
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, is(nullValue()));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, is(nullValue()));
     }
 
     /**
      * {@link Main#execute(CommandLine)}のテスト。
      * <p/>
-     * 処理が異常終了する場合のテスト<br/>
+     * 一部メールの送信に失敗する場合のテスト<br/>
      * <br/>
      * （subjectに改行を設定して実行する）。
      *
      * @throws Exception
      */
     @Test
-    public void testExecuteAbnormalEndHeaderInjectionSubject() throws Exception {
+    public void testSendFailHeaderInjectionSubject() throws Exception {
 
         // データ準備
         String mailRequestId = "1";
@@ -921,13 +1350,21 @@ public class MailSenderTest extends MailTestSupport {
                 "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("2つ目が送信失敗になるが中断せず戻り値は0となる。", execute, is(0));
 
         // ----- assert log -----
         //LogVerifier.verify("assert log");
 
-        // 異常系送信結果
-        assertError(MailTestErrorHandler.catched, "2", mailConfig.getAbnormalEndExitCode());
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "メールを送信しました。 mailRequestId=[1]",
+                "メール送信に失敗しました。 mailRequestId=[2]",
+                "メールを送信しました。 mailRequestId=[3]");
+        //障害通知ログに[2]が１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[2]"
+                ), 1);
 
         // DBの検証（ステータスと送信日時）
         List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
@@ -939,37 +1376,14 @@ public class MailSenderTest extends MailTestSupport {
         assertThat("ステータスが「送信失敗」になっているはず", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
         assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, is(nullValue()));
         assertThat("メールリクエストIDが3", mailRequestList.get(2).mailRequestId, is("3"));
-        assertThat("ステータスが「未送信」のままのはず", mailRequestList.get(2).status, is(mailConfig.getStatusUnsent()));
-        assertThat("送信日時が登録されていないはず", mailRequestList.get(2).sendDatetime, is(nullValue()));
-
-        // バッチ実行
-        commandLine = new CommandLine("-diConfig",
-                "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
-                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
-        execute = Main.execute(commandLine);
-        assertThat("正常終了なので戻り値は0となる。", execute, is(0));
-
-        // 異常系送信結果
-        assertError(MailTestErrorHandler.catched, "2", mailConfig.getAbnormalEndExitCode());
-
-        // DBの検証（ステータスと送信日時）
-        mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
-        assertThat("レコード取得数", mailRequestList.size(), is(3));
-        assertThat("メールリクエストIDが1", mailRequestList.get(0).mailRequestId, is("1"));
-        assertThat("ステータスが「送信成功」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusSent()));
-        assertThat("送信日時が登録されているはず", mailRequestList.get(0).sendDatetime, is(notNullValue()));
-        assertThat("メールリクエストIDが2", mailRequestList.get(1).mailRequestId, is("2"));
-        assertThat("ステータスが「送信失敗」になっているはず", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
-        assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, is(nullValue()));
-        assertThat("メールリクエストIDが3", mailRequestList.get(2).mailRequestId, is("3"));
-        assertThat("ステータスが「送信成功」になっているはず", mailRequestList.get(2).status, is(mailConfig.getStatusSent()));
+        assertThat("ステータスが「送信成功」のままのはず", mailRequestList.get(2).status, is(mailConfig.getStatusSent()));
         assertThat("送信日時が登録されているはず", mailRequestList.get(2).sendDatetime, is(notNullValue()));
     }
 
     /**
      * {@link Main#execute(CommandLine)}のテスト。
      * <p/>
-     * 処理が異常終了する場合のテスト<br/>
+     * 一部メールの送信に失敗する場合のテスト<br/>
      * <br/>
      * （ReturnPathに改行を設定して実行する）。
      *
@@ -977,7 +1391,7 @@ public class MailSenderTest extends MailTestSupport {
      */
     @Test
     @TargetDb(exclude = TargetDb.Db.DB2) // DB2では本ケース実行後にDB2が停止してしまうため暫定対処。
-    public void testExecuteAbnormalEndHeaderInjectionReturnPath() throws Exception {
+    public void testSendFailHeaderInjectionReturnPath() throws Exception {
 
         // データ準備
         String mailRequestId = "1";
@@ -1026,39 +1440,24 @@ public class MailSenderTest extends MailTestSupport {
                 "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
                 "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
         int execute = Main.execute(commandLine);
-        assertThat("異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+        assertThat("2つ目が送信失敗となるが中断せず戻り値は0となる。", execute, is(0));
 
         // ----- assert log -----
         //LogVerifier.verify("assert log");
 
-        // 異常系送信結果
-        assertError(MailTestErrorHandler.catched, "2", mailConfig.getAbnormalEndExitCode());
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "メールを送信しました。 mailRequestId=[1]",
+                "メール送信に失敗しました。 mailRequestId=[2]",
+                "メールを送信しました。 mailRequestId=[3]");
+        //障害通知ログに[2]が１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[2]"
+                ), 1);
 
         // DBの検証（ステータスと送信日時）
-        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
-        assertThat("レコード取得数", mailRequestList.size(), is(3));
-        assertThat("メールリクエストIDが1", mailRequestList.get(0).mailRequestId, is("1"));
-        assertThat("ステータスが「送信成功」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusSent()));
-        assertThat("送信日時が登録されているはず", mailRequestList.get(0).sendDatetime, is(notNullValue()));
-        assertThat("メールリクエストIDが2", mailRequestList.get(1).mailRequestId, is("2"));
-        assertThat("ステータスが「送信失敗」になっているはず", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
-        assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, is(nullValue()));
-        assertThat("メールリクエストIDが3", mailRequestList.get(2).mailRequestId, is("3"));
-        assertThat("ステータスが「未送信」のままのはず", mailRequestList.get(2).status, is(mailConfig.getStatusUnsent()));
-        assertThat("送信日時が登録されていないはず", mailRequestList.get(2).sendDatetime, is(nullValue()));
-
-        // バッチ実行
-        commandLine = new CommandLine("-diConfig",
-                "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
-                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
-        execute = Main.execute(commandLine);
-        assertThat("正常終了なので戻り値は0となる。", execute, is(0));
-
-        // 異常系送信結果
-        assertError(MailTestErrorHandler.catched, "2", mailConfig.getAbnormalEndExitCode());
-
-        // DBの検証（ステータスと送信日時）
-        mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        final List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
         assertThat("レコード取得数", mailRequestList.size(), is(3));
         assertThat("メールリクエストIDが1", mailRequestList.get(0).mailRequestId, is("1"));
         assertThat("ステータスが「送信成功」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusSent()));
@@ -1070,6 +1469,496 @@ public class MailSenderTest extends MailTestSupport {
         assertThat("ステータスが「送信成功」になっているはず", mailRequestList.get(2).status, is(mailConfig.getStatusSent()));
         assertThat("送信日時が登録されているはず", mailRequestList.get(2).sendDatetime, is(notNullValue()));
 
+    }
+
+    /**
+     * ステータス更新処理が異常終了する場合のテスト<br/>
+     * <br/>
+     * メール送信失敗→未送信へのステータス更新に失敗する場合は処理がリトライ構成でも異常終了すること。
+     */
+    @Test
+    public void testSendFailAndUnsentStatusUpdateFail() throws Exception {
+        new MockUp<Transport>() {
+            @Mock
+            void send(Message message) throws MessagingException {
+                throw new MessagingException("Test MessagingException.");
+            }
+        };
+
+        new MockUp<MailRequestTable>() {
+            @Mock
+            void updateFailureStatus(final String mailRequestId, final String status) {
+                throw new DbAccessException("db error!!!!", new SQLException());
+            }
+        };
+
+        // データ準備
+        String mailRequestId = "1";
+        String subject = "異常系 送信失敗へのDB更新失敗";
+        VariousDbTestHelper.setUpTable(
+                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+        VariousDbTestHelper.setUpTable(
+                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+
+        OnMemoryLogWriter.clear();
+
+        // バッチ実行 (リトライするハンドラ構成でのテスト)
+        CommandLine commandLine = new CommandLine("-diConfig",
+                "nablarch/common/mail/MailSenderTestRetry.xml", "-requestPath",
+                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
+        int rc = Main.execute(commandLine);
+        assertThat("送信失敗ステータスへの更新失敗なので異常終了する", rc, is(mailConfig.getAbnormalEndExitCode()));
+
+        // ----- assert log -----
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Failed to update unsent status. Need to apply a patch to change the status to failure. mailRequestId=[1]",
+                "[199 ProcessAbnormalEnd] メール送信に失敗しました。 mailRequestId=[1]"
+        );
+        //障害通知ログに[1]と、パッチ適用メッセージが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "nablarch.common.mail.SendStatusUpdateFailureException: Failed to update unsent status. Need to apply a patch to change the status to failure. mailRequestId=[1]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
+        assertThat("レコード取得数", mailRequestList.size(), is(1));
+        assertThat("メールリクエストIDが1", mailRequestList.get(0).mailRequestId, is("1"));
+        assertThat("ステータス更新が失敗し、「送信済み」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusSent()));
+        assertThat("送信日時が登録されているはず", mailRequestList.get(0).sendDatetime, notNullValue());
+    }
+
+    /**
+     * ステータス更新処理が異常終了する場合のテスト<br/>
+     * <br/>
+     * メール送信失敗(リトライ例外)→ステータス更新に失敗する場合は処理が異常終了すること。
+     */
+    @Test
+    public void testSendFailAndFailureStatusUpdateFail() throws Exception {
+
+        new MockUp<MailRequestTable>() {
+            @Mock
+            void updateFailureStatus(final String mailRequestId, final String status) {
+                throw new DbAccessException("db error!!!!", new SQLException());
+            }
+        };
+
+        // データ準備
+        String mailRequestId = "1";
+        String subject = "正常系";
+        VariousDbTestHelper.setUpTable(
+                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+        VariousDbTestHelper.setUpTable(
+                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+
+        mailRequestId = "2";
+        subject = "異常系(returnPathに改行)";
+
+        VariousDbTestHelper.insert(
+                new MailRequest(mailRequestId, subject, from, replyTo, returnPath + ">\nRCPT TO: <to2@localhost>",
+                        charset, mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+        VariousDbTestHelper.insert(
+                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+
+        mailRequestId = "3";
+        subject = "正常系";
+
+        VariousDbTestHelper.insert(
+                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+
+        VariousDbTestHelper.insert(
+                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+
+        OnMemoryLogWriter.clear();
+
+        // バッチ実行
+        CommandLine commandLine = new CommandLine("-diConfig",
+                "nablarch/common/mail/MailSenderTestRetry.xml", "-requestPath",
+                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
+        int rc = Main.execute(commandLine);
+        assertThat("送信失敗ステータスへの更新失敗なので異常終了する", rc, is(mailConfig.getAbnormalEndExitCode()));
+
+        // ----- assert log -----
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "メールを送信しました。 mailRequestId=[1]",
+                "メール送信に失敗しました。 mailRequestId=[2]",
+                "Failed to update unsent status. Need to apply a patch to change the status to failure. mailRequestId=[2]");
+        //障害通知ログに[2]と、パッチ適用メッセージが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[2]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "nablarch.common.mail.SendStatusUpdateFailureException: Failed to update unsent status. Need to apply a patch to change the status to failure. mailRequestId=[2]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(3));
+
+        // id:1(success)
+        assertThat("メールリクエストIDが1", mailRequestList.get(0).mailRequestId, is("1"));
+        assertThat("ステータスが「送信成功」になっているはず", mailRequestList.get(0).status, is(mailConfig.getStatusSent()));
+        assertThat("送信日時が登録されているはず", mailRequestList.get(0).sendDatetime, is(notNullValue()));
+
+        // id:2(fail)
+        assertThat("メールリクエストIDが2", mailRequestList.get(1).mailRequestId, is("2"));
+        assertThat("送信失敗への変更に失敗するので「送信済み」のまま", mailRequestList.get(1).status, is(mailConfig.getStatusSent()));
+        assertThat("送信日時が登録されているはず", mailRequestList.get(1).sendDatetime, is(notNullValue()));
+
+        // id:3(unsent)
+        assertThat("メールリクエストIDが3", mailRequestList.get(2).mailRequestId, is("3"));
+        assertThat("ステータスが「未送信」になっているはず", mailRequestList.get(2).status, is(mailConfig.getStatusUnsent()));
+        assertThat("送信日時が未更新(null)", mailRequestList.get(2).sendDatetime, is(nullValue()));
+    }
+
+    /**
+     * メール送信の実行時に{@link SendFailedException}が発生した場合、詳細のログがERRORに出力され、異常終了していることのテスト
+     */
+    @Test
+    public void testSendFailBySendFailedException() {
+        new MockUp<Transport>() {
+
+            @Mock
+            public void send(Message message) throws MessagingException {
+                // 複数アドレスの場合、間に ", " が入る
+                final Address[] validSent = {new InternetAddress(to1), new InternetAddress(to2), new InternetAddress(cc1)};
+                // １アドレスの場合
+                final Address[] validUnsent = {new InternetAddress(to3)};
+                // 空の場合
+                final Address[] invalid = {};
+                throw new SendFailedException("Test SendFailedException message.", null,
+                        validSent, validUnsent, invalid);
+            }
+        };
+
+        // データ準備
+        String mailRequestId = "1";
+        String subject = "異常系 Transport.Sendで失敗";
+        VariousDbTestHelper.setUpTable(
+                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+        VariousDbTestHelper.setUpTable(
+                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId, 2L, mailConfig.getRecipientTypeTO(), to2),
+                new MailRecipient(mailRequestId, 3L, mailConfig.getRecipientTypeTO(), to3),
+                new MailRecipient(mailRequestId, 4L, mailConfig.getRecipientTypeTO(), cc1));
+
+        // バッチ実行
+        CommandLine commandLine = new CommandLine("-diConfig",
+                "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
+                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
+        int execute = Main.execute(commandLine);
+        assertThat("送信失敗は異常終了ではなく戻り値は0となる。", execute, is(0));
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Failed to send a mail. Error message:[Test SendFailedException message.] Mail RequestId:[1] "
+                        + "Sent address:[to1@localhost, to2@localhost, cc1@localhost] Unsent address:[to3@localhost] Invalid address:[]",
+                         "メール送信に失敗しました。 mailRequestId=[1]");
+        //障害通知ログに[1]と、メール送信失敗のアドレスの詳細が１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "Failed to send a mail. Error message:[Test SendFailedException message.] Mail RequestId:[1] ",
+                        "Sent address:[to1@localhost, to2@localhost, cc1@localhost] Unsent address:[to3@localhost] Invalid address:[]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
+        assertThat("レコード取得数", mailRequestList.size(), is(1));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時がnullのまま", mailRequestList.get(0).sendDatetime, nullValue());
+    }
+
+    /**
+     * メール送信の実行時に{@link SendFailedException}が発生した場合、詳細のログがERRORに出力され、異常終了していることのテスト
+     */
+    @Test
+    public void testSendFailBySendFailedExceptionNullAddresses() {
+        new MockUp<Transport>() {
+
+            @Mock
+            public void send(Message message) throws MessagingException {
+                // nullの場合
+                final Address[] validSent = null;
+                final Address[] validUnsent = null;
+                final Address[] invalid = null;
+                throw new SendFailedException("Test SendFailedException message.", null,
+                        validSent, validUnsent, invalid);
+            }
+        };
+
+        // データ準備
+        String mailRequestId = "1";
+        String subject = "異常系 Transport.Sendで失敗";
+        VariousDbTestHelper.setUpTable(
+                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+        VariousDbTestHelper.setUpTable(
+                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId, 2L, mailConfig.getRecipientTypeTO(), to2),
+                new MailRecipient(mailRequestId, 3L, mailConfig.getRecipientTypeTO(), to3),
+                new MailRecipient(mailRequestId, 4L, mailConfig.getRecipientTypeTO(), cc1));
+
+        // バッチ実行
+        CommandLine commandLine = new CommandLine("-diConfig",
+                "nablarch/common/mail/MailSenderTest.xml", "-requestPath",
+                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
+        int execute = Main.execute(commandLine);
+        assertThat("送信失敗は異常終了ではなく戻り値は0となる。", execute, is(0));
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Failed to send a mail. Error message:[Test SendFailedException message.] Mail RequestId:[1] "
+                        + "Sent address:[] Unsent address:[] Invalid address:[]",
+                "メール送信に失敗しました。 mailRequestId=[1]");
+        //障害通知ログに[1]と、メール送信失敗のアドレスの詳細が１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "Failed to send a mail. Error message:[Test SendFailedException message.] Mail RequestId:[1] ",
+                        "Sent address:[] Unsent address:[] Invalid address:[]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
+        assertThat("レコード取得数", mailRequestList.size(), is(1));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時がnullのまま", mailRequestList.get(0).sendDatetime, nullValue());
+    }
+
+    /**
+     * メール送信の実行時に{@link SendFailedException}が発生し、リトライ例外を送出せずに
+     * {@link nablarch.fw.launcher.ProcessAbnormalEnd}を送出してプロセス異常終了するテスト
+     */
+    @Test
+    public void testNoRetryableExceptionAndProcessAbnormalEnd() {
+
+        new MockUp<Transport>() {
+
+            @Mock
+            public void send(Message message) throws MessagingException {
+                throw new RuntimeException("Test RuntimeException message in Transport.send.");
+            }
+        };
+
+        // データ準備
+        String mailRequestId = "1";
+        String subject = "異常系 Transport.Sendで失敗（リトライしない）";
+        VariousDbTestHelper.setUpTable(
+                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+        VariousDbTestHelper.setUpTable(
+                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+
+        // バッチ実行 (リトライするハンドラ構成でのテスト)
+        CommandLine commandLine = new CommandLine("-diConfig",
+                "nablarch/common/mail/MailSenderTestRetry.xml", "-requestPath",
+                "nablarch.common.mail.NoRetryMailSender/SENDMAIL00", "-userId", "hoge");
+        int execute = Main.execute(commandLine);
+        assertThat("プロセスの異常終了なので戻り値は199となる。", execute, is(mailConfig.getAbnormalEndExitCode()));
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "Test RuntimeException message in Transport.send.",
+                "[199 ProcessAbnormalEnd] メール送信に失敗しました。 mailRequestId=[1]" // プロセス異常終了ログ
+        );
+        //障害通知ログに[1]が１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        " -ERROR- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
+        assertThat("レコード取得数", mailRequestList.size(), is(1));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時がnullのまま", mailRequestList.get(0).sendDatetime, nullValue());
+    }
+
+    /**
+     * メール送信の実行時に{@link SendFailedException}が発生し、リトライ例外を送出しなかった場合に
+     * {@link nablarch.fw.launcher.ProcessAbnormalEnd}となるテスト
+     */
+    @Test
+    public void testRethrowProcessAbnormalEnd() {
+
+        new MockUp<Transport>() {
+
+            @Mock
+            public void send(Message message) throws MessagingException {
+                throw new ProcessAbnormalEnd(198,"SEND_FAIL0", "1");
+            }
+        };
+
+        // データ準備
+        String mailRequestId = "1";
+        String subject = "異常系 Transport.Sendで失敗";
+        VariousDbTestHelper.setUpTable(
+                new MailRequest(mailRequestId, subject, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+        VariousDbTestHelper.setUpTable(
+                new MailRecipient(mailRequestId, 1L, mailConfig.getRecipientTypeTO(), to1));
+
+        // バッチ実行 (リトライするハンドラ構成でのテスト)
+        CommandLine commandLine = new CommandLine("-diConfig",
+                "nablarch/common/mail/MailSenderTestRetry.xml", "-requestPath",
+                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
+        int execute = Main.execute(commandLine);
+        assertThat("プロセスの異常終了を再送出するので戻り値はその例外の値の198となる。", execute, is(198));
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "[198 ProcessAbnormalEnd] メール送信に失敗しました。 mailRequestId=[1]" // 再送出のプロセス異常終了ログ
+        );
+        //障害通知ログに再送出したメッセージが１回出力されていること
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "-FATAL- MONITOR [",
+                        "] boot_proc = [] proc_sys = [] req_id = [SENDMAIL00] usr_id = [hoge] fail_code = [SEND_FAIL0] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+        assertLogWithCount("writer.failure-memory",
+                createMessagePattern(
+                        "[198 ProcessAbnormalEnd] メール送信に失敗しました。 mailRequestId=[1]"
+                ), 1);
+
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class);
+        assertThat("レコード取得数", mailRequestList.size(), is(1));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時がnullのまま", mailRequestList.get(0).sendDatetime, nullValue());
+    }
+
+    /**
+     * メール送信の実行時に{@link MessagingException}が発生し、リトライ上限に達するテスト
+     */
+    @Test
+    public void testRetryableExceptionAndExceedRetryCount() throws Exception {
+
+        new MockUp<Transport>() {
+
+            @Mock
+            public void send(Message message) throws MessagingException {
+                throw new MessagingException("Test MessagingException message.");
+            }
+        };
+
+        // データ準備
+        String mailRequestId1 = "1";
+        String subject1 = "リトライ1回目";
+        String mailRequestId2 = "2";
+        String subject2 = "リトライ上限で失敗";
+        VariousDbTestHelper.setUpTable(
+                new MailRequest(mailRequestId1, subject1, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody),
+                new MailRequest(mailRequestId2, subject2, from, replyTo, returnPath, charset,
+                        mailConfig.getStatusUnsent(), SystemTimeUtil.getTimestamp(), null, mailBody));
+        VariousDbTestHelper.setUpTable(
+                new MailRecipient(mailRequestId1, 1L, mailConfig.getRecipientTypeTO(), to1),
+                new MailRecipient(mailRequestId2, 2L, mailConfig.getRecipientTypeTO(), to1));
+
+        // バッチ実行 (リトライするハンドラ構成でのテスト)
+        CommandLine commandLine = new CommandLine("-diConfig",
+                "nablarch/common/mail/MailSenderTestRetry.xml", "-requestPath",
+                "nablarch.common.mail.MailSender/SENDMAIL00", "-userId", "hoge");
+        int execute = Main.execute(commandLine);
+        assertThat("リトライ上限超過による異常終了なので戻り値は180となる。", execute, is(180));
+
+        OnMemoryLogWriter.assertLogContains("writer.memory",
+                "caught a exception to retry. start retry. retryCount[1]",
+                "retry process failed. retry limit was exceeded." // 2通目でリトライ上限を超える。
+        );
+        // DBの検証（ステータスと送信日時）
+        List<MailRequest> mailRequestList = VariousDbTestHelper.findAll(MailRequest.class, "mailRequestId");
+        assertThat("レコード取得数", mailRequestList.size(), is(2));
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(0).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(0).sendDatetime, nullValue());
+        assertThat("ステータスが「送信失敗」", mailRequestList.get(1).status, is(mailConfig.getStatusFailure()));
+        assertThat("送信日時が登録されていないはず", mailRequestList.get(1).sendDatetime, nullValue());
+    }
+
+    private void assertRecivingPlainMail(final String account, final String fromAddress, final String replyToAddress, final String mailSubject, final String to[],
+            final String cc[]) throws Exception {
+        // accountでメールを受信
+        Session session = Session.getInstance(sessionProperties, new Authenticator() {
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(account, "default");
+            }
+        });
+        Store store = session.getStore("pop3");
+        store.connect();
+        //メールの削除と取得のタイムラグの間に他のテストケースで送信したメールが複数届く場合があるため、
+        //Subjectが一致するものを待つ。
+        Folder folder = openFolder(store, mailSubject);
+        Message[] messages = folder.getMessages();
+        Message message = null;
+        for (Message mail: messages ) {
+            if( mailSubject.equals(mail.getSubject()) ) {
+                message = mail;
+                break;
+            }
+        }
+        assertThat("件名[" + mailSubject + "]が一致するメールが届いていない", message, notNullValue());
+
+        // メールの検証
+        // FROM
+        Address[] messageFrom = message.getFrom();
+        assertThat("fromアドレスの数", messageFrom.length, is(1));
+        assertThat("fromアドレス", ((InternetAddress) messageFrom[0]).getAddress(), is(fromAddress));
+        // TO
+        Address[] messageTO = message.getRecipients(RecipientType.TO);
+        if (messageTO == null) {
+            assertThat( "TOがnullなのでtos[]は空のはず", to.length, is(0));
+        } else {
+            assertThat("TOアドレスの数", messageTO.length, is(to.length));
+        }
+        for (int i=0; i<to.length; i++) {
+            assertThat("TOアドレス " + (i+1), ((InternetAddress) messageTO[i]).getAddress(), is(to[i]));
+        }
+        // CC
+        Address[] messageCC = message.getRecipients(RecipientType.CC);
+        if (messageCC == null) {
+            assertThat( "CCがnullなのでccs[]は空のはず", cc.length, is(0));
+        } else {
+            assertThat("CCアドレスの数", messageCC.length, is(cc.length));
+        }
+        for (int i=0; i<cc.length; i++) {
+            assertThat("CCアドレス " + (i+1), ((InternetAddress) messageCC[i]).getAddress(), is(cc[i]));
+        }
+        // BCCは検証できない
+
+        // ReplyTo
+        Address[] messageReplyTo = message.getReplyTo();
+        assertThat("ReplyToの数", messageReplyTo.length, is(1));
+        assertThat("ReplyToアドレス", ((InternetAddress) messageReplyTo[0]).getAddress(), is(replyToAddress));
+        // Return-Path
+        String[] messageReturnPath = message.getHeader("Return-Path");
+        assertThat("RetrunPathの数", messageReturnPath.length, is(1));
+        assertThat("RetrunPathアドレス", messageReturnPath[0], is("<" + returnPath + ">"));
+        // Subject
+        String messageSubject = message.getSubject();
+        assertThat("件名", messageSubject, is(mailSubject));
+        // Content-Type
+        assertThat("Content-Type", message.getContentType(), containsString("text/plain"));
+        // Body
+        assertThat("添付ファイルなしなので", message.getContent(), is(instanceOf(String.class)));
+        assertThat("本文", (String) message.getContent(), is(mailBody));
     }
 
     public static class MailTestErrorHandler implements Handler<Object, Object> {

--- a/src/test/java/nablarch/common/mail/NoRetryMailSender.java
+++ b/src/test/java/nablarch/common/mail/NoRetryMailSender.java
@@ -1,0 +1,27 @@
+package nablarch.common.mail;
+
+import nablarch.core.db.statement.SqlRow;
+import nablarch.core.log.app.FailureLogUtil;
+import nablarch.core.util.annotation.Published;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Result;
+import nablarch.fw.launcher.ProcessAbnormalEnd;
+
+/**
+ * {@link MailSender#handleException(SqlRow, ExecutionContext, MailRequestTable.MailRequest, MailConfig, Exception)} の実装を変更した {@link MailSender}。<p/>
+ * 変更点
+ * <ul>
+ *     <li>{@link SendMailRetryableException}を送出しないで、{@link ProcessAbnormalEnd}を送出する。</li>
+ * </ul>
+ */
+public class NoRetryMailSender extends MailSender {
+
+    @Override
+    @Published(tag = "architect")
+    protected Result handleException(final SqlRow data, final ExecutionContext context,
+            final MailRequestTable.MailRequest mailRequest, final MailConfig mailConfig, final Exception e) {
+        FailureLogUtil.logError(e, data, mailConfig.getSendFailureCode(), mailRequest.getMailRequestId());
+        updateToFailed(data, context);
+        throw new ProcessAbnormalEnd(mailConfig.getAbnormalEndExitCode(), e, mailConfig.getSendFailureCode(),mailRequest.getMailRequestId());
+    }
+}

--- a/src/test/resources/log.properties
+++ b/src/test/resources/log.properties
@@ -1,15 +1,16 @@
 loggerFactory.className=nablarch.core.log.basic.BasicLoggerFactory
 
-writerNames=memory,stdout
+writerNames=memory,stdout,failure-memory
 
 writer.memory.className=nablarch.test.support.log.app.OnMemoryLogWriter
+writer.failure-memory.className=nablarch.test.support.log.app.OnMemoryLogWriter
 
 # stdout
 writer.stdout.className=nablarch.core.log.basic.StandardOutputLogWriter
 writer.stdout.formatter.className=nablarch.core.log.basic.BasicLogFormatter
 writer.stdout.formatter.format=$date$ -$logLevel$- $loggerName$ [$executionId$] req_id = [$requestId$] usr_id = [$userId$] $message$$information$$stackTrace$
 
-availableLoggersNamesOrder=mail,ROO
+availableLoggersNamesOrder=mail,MONITOR,ROO
 
 # ROO
 loggers.ROO.nameRegex=.*
@@ -20,3 +21,8 @@ loggers.ROO.writerNames=memory,stdout
 loggers.mail.nameRegex=nablarch.fw.action.BatchActionBase
 loggers.mail.level=INFO
 loggers.mail.writerNames=memory,stdout
+
+# FailureLog
+loggers.MONITOR.nameRegex=MONITOR
+loggers.MONITOR.level=ERROR
+loggers.MONITOR.writerNames=failure-memory,stdout

--- a/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTestConnectionTimeout.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTestConnectionTimeout.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
 
   <!-- 正常系の設定ファイルをインポート -->
-  <import file="nablarch/common/mail/MailSenderPatternIdSupportTest.xml" />
+  <import file="nablarch/common/mail/MailSenderPatternIdSupportTestRetry.xml" />
 
   <component name="mailSessionConfig" class="nablarch.common.mail.MailSessionConfig">
     <property name="mailSmtpHost" value="${mail.smtp.host}" />

--- a/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTestPortError.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTestPortError.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
 
   <!-- 正常系の設定ファイルをインポート -->
-  <import file="nablarch/common/mail/MailSenderPatternIdSupportTest.xml" />
+  <import file="nablarch/common/mail/MailSenderPatternIdSupportTestRetry.xml" />
 
   <component name="mailSessionConfig" class="nablarch.common.mail.MailSessionConfig">
     <property name="mailSmtpHost" value="${mail.smtp.host}" />

--- a/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTestRetry.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTestRetry.xml
@@ -21,10 +21,10 @@
     <import file="nablarch/common/mail/handler/residentProcessStop.xml" />
 
     <import file="nablarch/common/mail/message.xml" />
-    
+
     <!-- リクエストID抽出の実装 -->
     <component name="requestIdExtractor" class="nablarch.common.util.ShortRequestIdExtractor" />
-    
+
     <!--コミットログ実装 -->
     <component name="commitLogger" class="nablarch.core.log.app.BasicCommitLogger">
         <property name="interval" value="500" />
@@ -44,8 +44,20 @@
         <component class="nablarch.fw.handler.GlobalErrorHandler" />
         <!-- スレッドコンテキスト設定ハンドラ -->
         <component-ref name="threadContextHandler" />
-        <!-- 常駐化ハンドラ （テスト時は戻ってこさせるためにはずす） -->
-        <!--<component-ref name="processResidentHandler" /> -->
+
+        <!-- リトライハンドラ -->
+        <component name="retryHandler" class="nablarch.fw.handler.RetryHandler">
+          <property name="retryLimitExceededFailureCode" value="" />
+          <property name="retryContextFactory">
+            <component class="nablarch.fw.handler.retry.CountingRetryContextFactory">
+              <property name="retryCount" value="3" />          <!-- 3回リトライを行う -->
+              <property name="retryIntervals" value="500" />   <!-- リトライを実行するまで0.5秒待機する -->
+            </component>
+          </property>
+        </component>
+
+        <!-- 常駐化ハンドラ (Retryも含めてテストする) -->
+        <component-ref name="processResidentHandler" />
         <!--処理停止ハンドラ -->
         <component-ref name="processStopHandler" />
         <!-- データベース接続ハンドラ -->

--- a/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTestSendTimeout.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderPatternIdSupportTestSendTimeout.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
 
   <!-- 正常系の設定ファイルをインポート -->
-  <import file="nablarch/common/mail/MailSenderPatternIdSupportTest.xml" />
+  <import file="nablarch/common/mail/MailSenderPatternIdSupportTestRetry.xml" />
 
   <component name="mailSessionConfig" class="nablarch.common.mail.MailSessionConfig">
     <property name="mailSmtpHost" value="${mail.smtp.host}" />

--- a/src/test/resources/nablarch/common/mail/MailSenderTest.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderTest.xml
@@ -33,7 +33,14 @@
         <property name="interval" value="500" />
     </component>
 
-    <!-- ハンドラキュー構成 -->
+  <!-- ステータス更新用のトランザクション -->
+    <component name="statusUpdateTransaction" class="nablarch.core.db.transaction.SimpleDbTransactionManager">
+        <property name="dbTransactionName" value="statusUpdateTransaction" />
+        <property name="connectionFactory" ref="connectionFactory" />
+        <property name="transactionFactory" ref="jdbcTransactionFactory" />
+    </component>
+
+  <!-- ハンドラキュー構成 -->
     <list name="handlerQueue">
         <!-- ステータスコードを終了コードに変換するハンドラ -->
         <component class="nablarch.fw.handler.StatusCodeConvertHandler" />

--- a/src/test/resources/nablarch/common/mail/MailSenderTestOverrideSmtpConnetcionTimeout.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderTestOverrideSmtpConnetcionTimeout.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
 
     <!-- 正常系の設定ファイルをインポート -->
-    <import file="nablarch/common/mail/MailSenderTest.xml" />
+    <import file="nablarch/common/mail/MailSenderTestRetry.xml" />
 
     <!-- 接続タイムアウト値をオーバーライド（確実にタイムアウトを発生させるために接続ポートも変える） -->
     <component name="mailSessionConfig" class="nablarch.common.mail.MailSessionConfig">

--- a/src/test/resources/nablarch/common/mail/MailSenderTestOverrideSmtpPort.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderTestOverrideSmtpPort.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
 
     <!-- 正常系の設定ファイルをインポート -->
-    <import file="nablarch/common/mail/MailSenderTest.xml" />
+    <import file="nablarch/common/mail/MailSenderTestRetry.xml" />
 
     <component name="mailSessionConfig" class="nablarch.common.mail.MailSessionConfig">
         <property name="mailSmtpHost" value="${mail.smtp.host}" />

--- a/src/test/resources/nablarch/common/mail/MailSenderTestOverrideSmtpTimeout.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderTestOverrideSmtpTimeout.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
 
     <!-- 正常系の設定ファイルをインポート -->
-    <import file="nablarch/common/mail/MailSenderTest.xml" />
+    <import file="nablarch/common/mail/MailSenderTestRetry.xml" />
 
     <!-- 接続エラーを発生させるためにポート番号をオーバーライド -->
     <component name="mailSessionConfig" class="nablarch.common.mail.MailSessionConfig">

--- a/src/test/resources/nablarch/common/mail/MailSenderTestRetry.xml
+++ b/src/test/resources/nablarch/common/mail/MailSenderTestRetry.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
+
+  <config-file file="nablarch/common/mail/mail-batch.config" />
+  <config-file file="nablarch/common/mail/mail-session.config" />
+
+  <import file="db-default.xml" />
+
+  <!-- メール関連テーブルスキーマ情報の定義ファイル -->
+  <import file="nablarch/common/mail/MailTableSchema.xml" />
+  <!-- 出力ライブラリ（メール送信）テストの共通定義ファイル -->
+  <import file="nablarch/common/mail/MailTestCommon.xml" />
+  <!-- スレッドコンテキストに保持される共通属性を管理するハンドラ -->
+  <import file="nablarch/common/mail/handler/threadcontext.xml" />
+  <!-- ２重起動防止ハンドラ -->
+  <import file="nablarch/common/mail/handler/duplicateProcessCheck.xml" />
+  <!-- 常駐化ハンドラ -->
+  <import file="nablarch/common/mail/handler/processResident.xml" />
+  <!-- 処理停止ハンドラ -->
+  <import file="nablarch/common/mail/handler/residentProcessStop.xml" />
+  <!-- データベース接続ハンドラ -->
+  <import file="nablarch/common/mail/handler/db.xml" />
+
+  <import file="nablarch/common/mail/message.xml" />
+
+  <!-- リクエストID抽出の実装 -->
+  <component name="requestIdExtractor" class="nablarch.common.util.ShortRequestIdExtractor" />
+
+  <!--コミットログ実装 -->
+  <component name="commitLogger" class="nablarch.core.log.app.BasicCommitLogger">
+    <property name="interval" value="500" />
+  </component>
+
+  <!-- ステータス更新用のトランザクション -->
+  <component name="statusUpdateTransaction" class="nablarch.core.db.transaction.SimpleDbTransactionManager">
+    <property name="dbTransactionName" value="statusUpdateTransaction" />
+    <property name="connectionFactory" ref="connectionFactory" />
+    <property name="transactionFactory" ref="jdbcTransactionFactory" />
+  </component>
+
+  <!-- ハンドラキュー構成 -->
+    <list name="handlerQueue">
+        <!-- ステータスコードを終了コードに変換するハンドラ -->
+        <component class="nablarch.fw.handler.StatusCodeConvertHandler" />
+        <!-- グローバルエラーハンドラ -->
+        <component class="nablarch.fw.handler.GlobalErrorHandler" />
+        <!-- エラー検証用の専用ハンドラ -->
+        <component
+            class="nablarch.common.mail.MailSenderTest$MailTestErrorHandler" />
+        <!-- スレッドコンテキスト設定ハンドラ -->
+        <component-ref name="threadContextHandler" />
+        <!-- ２重起動防止ハンドラ -->
+        <component-ref name="duplicateProcessCheckHandler" />
+
+        <!-- リトライハンドラ -->
+        <component name="retryHandler" class="nablarch.fw.handler.RetryHandler">
+          <property name="retryLimitExceededFailureCode" value="" />
+          <property name="retryContextFactory">
+            <component class="nablarch.fw.handler.retry.CountingRetryContextFactory">
+              <property name="retryCount" value="1" />          <!-- 1回リトライを行う -->
+              <property name="retryIntervals" value="500" />   <!-- リトライを実行するまで0.5秒待機する -->
+            </component>
+          </property>
+        </component>
+
+        <!-- 常駐化ハンドラ （Retryテストなので常駐化する） -->
+        <component-ref name="processResidentHandler" />
+        <!--処理停止ハンドラ -->
+        <component-ref name="processStopHandler" />
+        <!-- データベース接続ハンドラ -->
+        <component-ref name="dbConnectionManagementHandler" />
+        <!--トランザクションマネージャ -->
+        <component-ref name="transactionManagementHandler" />
+        <!-- ディスパッチ -->
+        <component class="nablarch.fw.handler.RequestPathJavaPackageMapping">
+            <property name="basePackage" value="." />
+            <property name="immediate" value="false" />
+        </component>
+        <!-- スレッド実行ハンドラ -->
+        <component class="nablarch.fw.handler.MultiThreadExecutionHandler">
+            <property name="concurrentNumber" value="${threadCount}" />
+            <property name="commitLogger" ref="commitLogger" />
+        </component>
+
+        <!-- データベース接続ハンドラ -->
+        <component-ref name="dbConnectionManagementHandler" />
+
+        <!-- ループ・トランザクション制御ハンドラ -->
+        <component class="nablarch.fw.handler.LoopHandler">
+            <property name="commitInterval" value="${commitInterval}" />
+            <property name="transactionFactory" ref="jdbcTransactionFactory" />
+        </component>
+
+        <!-- データリードハンドラ -->
+        <component class="nablarch.fw.handler.DataReadHandler">
+            <property name="maxCount" value="${maxCount}" />
+        </component>
+    </list>
+
+    <component name="mailSessionConfig" class="nablarch.common.mail.MailSessionConfig">
+      <property name="mailSmtpHost" value="${mail.smtp.host}" />
+      <property name="mailHost" value="${mail.host}" />
+      <property name="mailSmtpPort" value="${mail.smtp.port}" />
+      <property name="mailSmtpConnectionTimeout" value="${mail.smtp.connectiontimeout}" />
+      <property name="mailSmtpTimeout" value="${mail.smtp.timeout}" />
+      <property name="option">
+        <map>
+          <entry key="mail.debug" value="true" />
+        </map>
+      </property>
+    </component>
+
+    <component name="initializer"
+        class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+      <property name="initializeList">
+        <list>
+          <component-ref name="duplicateProcessChecker" />
+          <component-ref name="processStopHandler" />
+          <component-ref name="mailRequestTable" />
+          <component-ref name="mailRecipientTable" />
+          <component-ref name="mailAttachedFileTable" />
+          <component-ref name="stringResourceCache" />
+        </list>
+      </property>
+    </component>
+
+    <!-- メールの送信日時をテストするため、SystemTimeUtil.getDateを固定化するSystemTimeProvider -->
+    <component name="systemTimeProvider" class="nablarch.common.mail.MailSenderTest$TestSystemTimeProvider" />
+
+    <!-- オブジェクトの情報のキャッシュ設定 -->
+    <component name="statementValueObjectCache" class="nablarch.core.cache.BasicStaticDataCache">
+      <property name="loader">
+        <component
+            class="nablarch.core.db.statement.autoproperty.FieldAndAnnotationLoader" />
+      </property>
+      <property name="loadOnStartup" value="false" />
+    </component>
+
+</component-configuration>


### PR DESCRIPTION
変更前
* 送信先アドレス(To,CC,BCC)の生成処理でAddressExceptionが発生した際に、IllegalStateExceptionをスローしていたため、メール送信のバッチが異常終了しデータベースに送信失敗ステータスが書き込まれていなかった。

変更後
* メールアドレスの生成処理でAddressEceptionが発生した場合は、ERRORレベルのログを出力する。送信要求のアドレスの場合は送信失敗とし、それ以外のアドレスの場合は処理を継続する。
* メールヘッダーインジェクション対策で、InvalidCharactorExceptionが発生した場合は、送信失敗とする。
* メール送信失敗時に、SendFailedExceptionが発生した場合は、ERRORレベルのログを出力し、送信失敗とする。
* メール送信失敗以外のMessagingExceptionが発生した場合は、リトライ例外を送出する。